### PR TITLE
Clarify benchmark specs and numbers in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ An artificial social network dataset is used, generated via the [Faker](https://
 A shell script `generate_data.sh` is provided in the root directory of this repo that sequentially runs the Python scripts, generating the data for the nodes and edges for the social network. This is the recommended way to generate the data. A single positional argument is provided to the shell script: The number of person profiles to generate -- this is specified as an integer, as shown below.
 
 ```sh
-bash generate_data.sh 10000
+# Generate data with 100K persons and ~2.4M edges
+bash generate_data.sh 100000
 ```
 
 Running this command generates a series of files in the `output` directory, following which we can proceed to ingesting the data into a graph database.
@@ -42,7 +43,7 @@ See [./data/README.md](./data/README.md) for more details on each script that is
 
 ## Ingest the data into Neo4j or Kùzu
 
-Navigate to the [neo4j](./neo4j) and the [kuzudb](./kuzudb/) to see the instructions on how to ingest the data into each database.
+Navigate to the [neo4j](./neo4j) and the [kuzudb](./kuzudb/) directories to see the instructions on how to ingest the data into each database.
 
 ## Run the queries
 

--- a/kuzudb/README.md
+++ b/kuzudb/README.md
@@ -16,6 +16,8 @@ python build_graph.py --batch_size 50000
 
 ### Ingestion performance
 
+The numbers shown below are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph.
+
 As expected, the nodes load much faster than the edges, since there are many more edges than nodes. The run times for ingesting nodes and edges are output to the console.
 
 ```
@@ -73,7 +75,7 @@ As can be seen, the results are identical to those obtained from Neo4j.
 
 ### Query performance
 
-Query times for simple aggregation and path finding are relatively low. More advanced queries involving variable length paths will be studied later.
+The numbers shown below are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph. Query times for simple aggregation and path finding are relatively low. More advanced queries involving variable length paths will be studied later.
 
 Summary of run times:
 

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -32,6 +32,8 @@ python build_graph.py --batch_size 50000
 
 ### Ingestion performance
 
+The numbers shown below are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph.
+
 As expected, the nodes load much faster than the edges, since there are many more edges than nodes. In addition, the nodes in Neo4j are indexed (via uniqueness constraints), following which the edges are created based on a match on existing nodes. The run times for ingesting nodes and edges are output to the console.
 
 ```
@@ -143,7 +145,7 @@ Query script completed in 2.822013s
 
 ### Query performance
 
-Query times for simple aggregation and path finding are relatively low. More advanced queries involving variable length paths will be studied later.
+The numbers shown below are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph. Query times for simple aggregation and path finding are relatively low. More advanced queries involving variable length paths will be studied later.
 
 Summary of run times:
 


### PR DESCRIPTION
To ensure reproducibility, random seeds are used, and the docs now clarify the conditions under which the timing is performed, including what data generation script was run.

The numbers shown in the docs are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph.