### PR TITLE
Update timer and fix kuzudb queries

### DIFF
--- a/kuzudb/README.md
+++ b/kuzudb/README.md
@@ -42,20 +42,16 @@ The following questions are asked of the graph:
 * **Query 3**: What are the top 5 cities with the lowest average age of persons?
 * **Query 4**: How many persons between ages 30-40 are there in each country?
 
-## To do
-
-- [ ] Fix and optimize queries 2-4 (currently not working)
-
 #### Output
 
 ```
-Query 1 completed in 0.145473s
+Query 1 completed in 0.471904s
 
 Query 1:
  
         MATCH (follower:Person)-[:Follows]->(person:Person)
-        RETURN person.id AS personID, person.name AS name, count(follower) AS numFollowers
-        ORDER BY numFollowers DESC LIMIT 3
+        RETURN person.id AS personID, person.name AS name, count(follower.id) AS numFollowers
+        ORDER BY numFollowers DESC LIMIT 3;
     
 Top 3 most-followed persons:
 shape: (3, 3)
@@ -68,10 +64,71 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Queries completed in 0.2517s
+Query 2 completed in 0.604744s
+
+Query 2:
+ 
+        MATCH (follower:Person)-[:Follows]->(person:Person)
+        WITH person, count(follower.id) as numFollowers
+        ORDER BY numFollowers DESC LIMIT 1
+        MATCH (person) -[:LivesIn]-> (city:City)
+        RETURN person.name AS name, numFollowers, city.city AS city, city.state AS state, city.country AS country;
+    
+City in which most-followed person lives:
+shape: (1, 5)
+┌────────┬──────────────┬────────┬───────┬───────────────┐
+│ name   ┆ numFollowers ┆ city   ┆ state ┆ country       │
+│ ---    ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
+│ str    ┆ i64          ┆ str    ┆ str   ┆ str           │
+╞════════╪══════════════╪════════╪═══════╪═══════════════╡
+│ Rachel ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
+│ Cooper ┆              ┆        ┆       ┆               │
+└────────┴──────────────┴────────┴───────┴───────────────┘
+Query 3 completed in 0.013838s
+
+Query 3:
+ 
+        MATCH (p:Person) -[:LivesIn]-> (c:City)-[*1..2]-> (co:Country {country: $country})
+        RETURN c.city AS city, avg(p.age) AS averageAge
+        ORDER BY averageAge LIMIT 5;
+    
+Cities with lowest average age in Canada:
+shape: (5, 2)
+┌───────────┬────────────┐
+│ city      ┆ averageAge │
+│ ---       ┆ ---        │
+│ str       ┆ f64        │
+╞═══════════╪════════════╡
+│ Montreal  ┆ 37.310934  │
+│ Calgary   ┆ 37.592098  │
+│ Toronto   ┆ 37.705746  │
+│ Edmonton  ┆ 37.931609  │
+│ Vancouver ┆ 38.011002  │
+└───────────┴────────────┘
+Query 4 completed in 0.017481s
+
+Query 4:
+ 
+        MATCH (p:Person)-[:LivesIn]->(ci:City)-[*1..2]->(country:Country)
+        WHERE p.age > $age_lower AND p.age < $age_upper
+        RETURN country.country AS countries, count(country) AS personCounts
+        ORDER BY personCounts DESC LIMIT 3;
+    
+Persons between ages 30-40 in each country:
+shape: (3, 2)
+┌────────────────┬──────────────┐
+│ countries      ┆ personCounts │
+│ ---            ┆ ---          │
+│ str            ┆ i64          │
+╞════════════════╪══════════════╡
+│ United States  ┆ 24983        │
+│ Canada         ┆ 2514         │
+│ United Kingdom ┆ 1498         │
+└────────────────┴──────────────┘
+Queries completed in 1.1088s
 ```
 
-As can be seen, the results are identical to those obtained from Neo4j.
+As can be seen, Kùzu's results are identical to those obtained from Neo4j, while also being generated more than twice as quick.
 
 ### Query performance
 
@@ -79,9 +136,9 @@ The numbers shown below are for when we ingest 100K person nodes, ~10K location 
 
 Summary of run times:
 
-* Query 1: `0.145473s`
-* Query 2: TBD
-* Query 3: TBD
-* Query 4: TBD
+* Query 1: `0.471904s`
+* Query 2: `0.604744s`
+* Query 3: `0.013838s`
+* Query 4: `0.017481s`
 
-> 💡 Query 1 takes the longest to run -- around 150 ms. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.
+> 💡 All queries (including materializing the results to arrow tables and then polars) take just over 1 sec 🔥 to complete (Neo4j takes around 2x longer). Query 1 takes the longest to run -- around 0.5 sec. Queries 2 takes around 0.6 sec, and queries 3-4 are the fastest at ~0.15 sec. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.

--- a/kuzudb/build_graph.py
+++ b/kuzudb/build_graph.py
@@ -20,7 +20,7 @@ def create_person_node_table(conn: Connection) -> None:
                 name STRING,
                 gender STRING,
                 birthday DATE,
-                age INT32,
+                age INT64,
                 isMarried BOOLEAN,
                 PRIMARY KEY (id)
             )

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -12,13 +12,13 @@ def run_query1(conn: Connection) -> None:
     "Who are the top 3 most-followed persons in the network?"
     query = """
         MATCH (follower:Person)-[:Follows]->(person:Person)
-        RETURN person.id AS personID, person.name AS name, count(follower) AS numFollowers
-        ORDER BY numFollowers DESC LIMIT 3
+        RETURN person.id AS personID, person.name AS name, count(follower.id) AS numFollowers
+        ORDER BY numFollowers DESC LIMIT 3;
     """
     with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
         response = conn.execute(query)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"\nQuery 1:\n {query}")
-    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"Top 3 most-followed persons:\n{result}")
 
 
@@ -26,41 +26,39 @@ def run_query2(conn: Connection) -> None:
     "In which city does the most-followed person in the network live?"
     query = """
         MATCH (follower:Person)-[:Follows]->(person:Person)
-        WITH person, count(follower) as followers
-        ORDER BY followers DESC LIMIT 1
+        WITH person, count(follower.id) as numFollowers
+        ORDER BY numFollowers DESC LIMIT 1
         MATCH (person) -[:LivesIn]-> (city:City)
-        RETURN person.name AS name, followers AS numFollowers, city.city AS city
+        RETURN person.name AS name, numFollowers, city.city AS city, city.state AS state, city.country AS country;
     """
     with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
         response = conn.execute(query)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"\nQuery 2:\n {query}")
-    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"City in which most-followed person lives:\n{result}")
 
 
 def run_query3(conn: Connection, params: list[tuple[str, Any]]) -> None:
     "Which are the top 5 cities in a particular region of the world with the lowest average age in the network?"
     query = """
-        MATCH (country:Country)
-        WHERE co.country = $country
-        AND EXISTS { MATCH (p:Person)-[:LivesIn]->(ci:City)-[*..2]->(country) }
-        RETURN ci.city AS city, avg(p.age) AS averageAge
-        ORDER BY averageAge LIMIT 5
+        MATCH (p:Person) -[:LivesIn]-> (c:City)-[*1..2]-> (co:Country {country: $country})
+        RETURN c.city AS city, avg(p.age) AS averageAge
+        ORDER BY averageAge LIMIT 5;
     """
     with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
         response = conn.execute(query, parameters=params)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"\nQuery 3:\n {query}")
-    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
     print(f"Cities with lowest average age in {params[0][1]}:\n{result}")
 
 
 def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
     "How many persons between a certain age range are in each country?"
     query = """
-        MATCH (p:Person)-[:LivesIn]->(ci:City)-[*..2]->(country:Country)
+        MATCH (p:Person)-[:LivesIn]->(ci:City)-[*1..2]->(country:Country)
         WHERE p.age > $age_lower AND p.age < $age_upper
         RETURN country.country AS countries, count(country) AS personCounts
-        ORDER BY personCounts DESC LIMIT 3
+        ORDER BY personCounts DESC LIMIT 3;
     """
     with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
         response = conn.execute(query, parameters=params)
@@ -72,9 +70,9 @@ def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
 def main(conn: Connection) -> None:
     with Timer(name="queries", text="Queries completed in {:.4f}s"):
         run_query1(conn)
-        # run_query2(conn)
-        # run_query3(conn, params=[("country", "Canada")])
-        # run_query4(conn, params=[("age_lower", 30), ("age_upper", 40)])
+        run_query2(conn)
+        run_query3(conn, params=[("country", "Canada")])
+        run_query4(conn, params=[("age_lower", 30), ("age_upper", 40)])
 
 
 if __name__ == "__main__":

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -61,7 +61,7 @@ The following questions are asked of the graph:
 #### Output
 
 ```
-Query 1 completed in 0.016359s
+Query 1 completed in 1.880833s
 
 Query 1:
  
@@ -80,7 +80,7 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 2 completed in 0.002067s
+Query 2 completed in 0.601604s
 
 Query 2:
  
@@ -92,18 +92,19 @@ Query 2:
     
 City in which most-followed person lives:
 shape: (1, 5)
-┌───────────────┬──────────────┬────────┬───────┬───────────────┐
-│ name          ┆ numFollowers ┆ city   ┆ state ┆ country       │
-│ ---           ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
-│ str           ┆ i64          ┆ str    ┆ str   ┆ str           │
-╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
-│ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
-└───────────────┴──────────────┴────────┴───────┴───────────────┘
-Query 3 completed in 0.002484s
+┌────────┬──────────────┬────────┬───────┬───────────────┐
+│ name   ┆ numFollowers ┆ city   ┆ state ┆ country       │
+│ ---    ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
+│ str    ┆ i64          ┆ str    ┆ str   ┆ str           │
+╞════════╪══════════════╪════════╪═══════╪═══════════════╡
+│ Rachel ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
+│ Cooper ┆              ┆        ┆       ┆               │
+└────────┴──────────────┴────────┴───────┴───────────────┘
+Query 3 completed in 0.059216s
 
 Query 3:
  
-        MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*..2]-> (co:Country {country: $country})
+        MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*1..2]-> (co:Country {country: $country})
         RETURN c.city AS city, avg(p.age) AS averageAge
         ORDER BY averageAge LIMIT 5
     
@@ -120,11 +121,11 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.931609  │
 │ Vancouver ┆ 38.011002  │
 └───────────┴────────────┘
-Query 4 completed in 0.001473s
+Query 4 completed in 0.085356s
 
 Query 4:
  
-        MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*..2]->(country:Country)
+        MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*1..2]->(country:Country)
         WHERE p.age > $age_lower AND p.age < $age_upper
         RETURN country.country AS countries, count(country) AS personCounts
         ORDER BY personCounts DESC LIMIT 3
@@ -140,7 +141,7 @@ shape: (3, 2)
 │ Canada         ┆ 2514         │
 │ United Kingdom ┆ 1498         │
 └────────────────┴──────────────┘
-Query script completed in 2.822013s
+Query script completed in 2.632767s
 ```
 
 ### Query performance
@@ -149,9 +150,9 @@ The numbers shown below are for when we ingest 100K person nodes, ~10K location 
 
 Summary of run times:
 
-* Query 1: `0.016359s`
-* Query 2: `0.002067s`
-* Query 3: `0.002484s`
-* Query 4: `0.001473s`
+* Query 1: `1.880833s`
+* Query 2: `0.601604s`
+* Query 3: `0.059216s`
+* Query 4: `0.085356s`
 
-> 💡 Query 1 takes the longest to run -- around 16 ms. Queries 2-4 (excluding data processing in Python after retrieval) takes of the order of 2 ms. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.
+> 💡 All queries (including materializing the results to dict and then polars) take ~2.6 sec to complete. Query 1 takes the longest to run -- around 1.9 sec. Queries 2-4 take of the order of 0.6-0.8 sec. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.

--- a/neo4j/query.py
+++ b/neo4j/query.py
@@ -24,8 +24,8 @@ def run_query1(session: Session) -> None:
     """
     with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
         response = session.run(query)
+        result = pl.from_dicts(response.data())
     print(f"\nQuery 1:\n {query}")
-    result = pl.from_dicts(response.data())
     print(f"Top 3 most-followed persons:\n{result}")
 
 
@@ -40,8 +40,8 @@ def run_query2(session: Session) -> None:
     """
     with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
         response = session.run(query)
+        result = pl.from_dicts(response.data())
     print(f"\nQuery 2:\n {query}")
-    result = pl.from_dicts(response.data())
     print(f"City in which most-followed person lives:\n{result}")
 
 
@@ -54,8 +54,8 @@ def run_query3(session: Session, country: str) -> None:
     """
     with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
         response = session.run(query, country=country)
+        result = pl.from_dicts(response.data())
     print(f"\nQuery 3:\n {query}")
-    result = pl.from_dicts(response.data())
     print(f"Cities with lowest average age in {country}:\n{result}")
 
 
@@ -69,8 +69,8 @@ def run_query4(session: Session, age_lower: int, age_upper: int) -> None:
     """
     with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
         response = session.run(query, age_lower=age_lower, age_upper=age_upper)
+        result = pl.from_dicts(response.data())
     print(f"\nQuery 4:\n {query}")
-    result = pl.from_dicts(response.data())
     print(f"Persons between ages {age_lower}-{age_upper} in each country:\n{result}")
 
 

--- a/neo4j/query.py
+++ b/neo4j/query.py
@@ -48,7 +48,7 @@ def run_query2(session: Session) -> None:
 def run_query3(session: Session, country: str) -> None:
     "Which are the top 5 cities in a particular region of the world with the lowest average age in the network?"
     query = """
-        MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*..2]-> (co:Country {country: $country})
+        MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*1..2]-> (co:Country {country: $country})
         RETURN c.city AS city, avg(p.age) AS averageAge
         ORDER BY averageAge LIMIT 5
     """
@@ -62,7 +62,7 @@ def run_query3(session: Session, country: str) -> None:
 def run_query4(session: Session, age_lower: int, age_upper: int) -> None:
     "How many persons between a certain age range are in each country?"
     query = """
-        MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*..2]->(country:Country)
+        MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*1..2]->(country:Country)
         WHERE p.age > $age_lower AND p.age < $age_upper
         RETURN country.country AS countries, count(country) AS personCounts
         ORDER BY personCounts DESC LIMIT 3


### PR DESCRIPTION
# Changes

Closes #7 
Closes #8 

## Timer update

Previously timer only record query execution time and ignore result iteration time. Depends on the database architecture, result iteration time may also be significant.

Disclaimer: I might be wrong about Neo4j architecture, so feel free to point it out. 

Based on previous observation of using Neo4j, Neo4j server client model doesn't materialize all query result by the end of `session.run()`. Instead, it relies on user's pulling action (i.e. consuming result) to continue execution. For example, if the query returns 10K tuple, `session.run()` might only materialize the first batch, say 1K. And as user requests more data, it will incrementally materialize the rest 9K tuples batch by batch. This makes a lot of sense in server-client architecture since we don't want to send large amount of data through network.

On the other hand, Kùzu is embedded and materialize all result by the end of `connection.execute()`. So I think the most straight forward comparison is to measure end-to-end time, i.e. the time from inputing a string query to the time of getting back an arrow table.

Timer is modified in both Kùzu and Neo4j in the same way.

## Kùzu query update

- Query 2: Remove secondary alias. This is a bug that should be fixed on Kùzu repo.
- Query 3: Replaced with the same query 3 as in Neo4j folder. Add lower bound 1 to variable length query.
- Query 4: Add lower bound 1 to variable length query.

For Kùzu team, I think we should try to be drop in replacement of Cypher so that user doesn't need to convert their queries. We should be able to do this for read/write statement for sure.


## Neo4j result
```
Query 1 completed in 2.493329s

Query 1:

        MATCH (follower:Person)-[:FOLLOWS]->(person:Person)
        RETURN person.personID AS personID, person.name AS name, count(follower) AS numFollowers
        ORDER BY numFollowers DESC LIMIT 3

Top 3 most-followed persons:
shape: (3, 3)
┌──────────┬────────────────┬──────────────┐
│ personID ┆ name           ┆ numFollowers │
│ ---      ┆ ---            ┆ ---          │
│ i64      ┆ str            ┆ i64          │
╞══════════╪════════════════╪══════════════╡
│ 85723    ┆ Rachel Cooper  ┆ 4998         │
│ 68753    ┆ Claudia Booker ┆ 4985         │
│ 54696    ┆ Brian Burgess  ┆ 4976         │
└──────────┴────────────────┴──────────────┘
Query 2 completed in 0.911550s

Query 2:

        MATCH (follower:Person) -[:FOLLOWS]-> (person:Person)
        WITH person, count(follower) as followers
        ORDER BY followers DESC LIMIT 1
        MATCH (person) -[:LIVES_IN]-> (city:City)
        RETURN person.name AS name, followers AS numFollowers, city.city AS city, city.state AS state, city.country AS country

City in which most-followed person lives:
shape: (1, 5)
┌───────────────┬──────────────┬────────┬───────┬───────────────┐
│ name          ┆ numFollowers ┆ city   ┆ state ┆ country       │
│ ---           ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
│ str           ┆ i64          ┆ str    ┆ str   ┆ str           │
╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
│ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
└───────────────┴──────────────┴────────┴───────┴───────────────┘
Query 3 completed in 0.152607s

Query 3:

        MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*..2]-> (co:Country {country: $country})
        RETURN c.city AS city, avg(p.age) AS averageAge
        ORDER BY averageAge LIMIT 5

Cities with lowest average age in Canada:
shape: (5, 2)
┌───────────┬────────────┐
│ city      ┆ averageAge │
│ ---       ┆ ---        │
│ str       ┆ f64        │
╞═══════════╪════════════╡
│ Montreal  ┆ 37.310934  │
│ Calgary   ┆ 37.592098  │
│ Toronto   ┆ 37.705746  │
│ Edmonton  ┆ 37.931609  │
│ Vancouver ┆ 38.011002  │
└───────────┴────────────┘
Query 4 completed in 0.156949s

Query 4:

        MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*..2]->(country:Country)
        WHERE p.age > $age_lower AND p.age < $age_upper
        RETURN country.country AS countries, count(country) AS personCounts
        ORDER BY personCounts DESC LIMIT 3

Persons between ages 30-40 in each country:
shape: (3, 2)
┌────────────────┬──────────────┐
│ countries      ┆ personCounts │
│ ---            ┆ ---          │
│ str            ┆ i64          │
╞════════════════╪══════════════╡
│ United States  ┆ 24983        │
│ Canada         ┆ 2514         │
│ United Kingdom ┆ 1498         │
└────────────────┴──────────────┘
Query script completed in 3.723656s
```

## Kùzu result
```
Query 1 completed in 1.177789s

Query 1:

        MATCH (follower:Person)-[:Follows]->(person:Person)
        RETURN person.id AS personID, person.name AS name, count(follower.id) AS numFollowers
        ORDER BY numFollowers DESC LIMIT 3;

Top 3 most-followed persons:
shape: (3, 3)
┌──────────┬────────────────┬──────────────┐
│ personID ┆ name           ┆ numFollowers │
│ ---      ┆ ---            ┆ ---          │
│ i64      ┆ str            ┆ i64          │
╞══════════╪════════════════╪══════════════╡
│ 85723    ┆ Rachel Cooper  ┆ 4998         │
│ 68753    ┆ Claudia Booker ┆ 4985         │
│ 54696    ┆ Brian Burgess  ┆ 4976         │
└──────────┴────────────────┴──────────────┘
Query 2 completed in 0.358639s

Query 2:

        MATCH (follower:Person)-[:Follows]->(person:Person)
        WITH person, count(follower.id) as numFollowers
        ORDER BY numFollowers DESC LIMIT 1
        MATCH (person) -[:LivesIn]-> (city:City)
        RETURN person.name AS name, numFollowers, city.city AS city, city.state AS state, city.country AS country;

City in which most-followed person lives:
shape: (1, 5)
┌───────────────┬──────────────┬────────┬───────┬───────────────┐
│ name          ┆ numFollowers ┆ city   ┆ state ┆ country       │
│ ---           ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
│ str           ┆ i64          ┆ str    ┆ str   ┆ str           │
╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
│ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
└───────────────┴──────────────┴────────┴───────┴───────────────┘
Query 3 completed in 0.014856s

Query 3:

        MATCH (p:Person) -[:LivesIn]-> (c:City)-[*1..2]-> (co:Country {country: $country})
        RETURN c.city AS city, avg(p.age) AS averageAge
        ORDER BY averageAge LIMIT 5;

Cities with lowest average age in Canada:
shape: (5, 2)
┌───────────┬────────────┐
│ city      ┆ averageAge │
│ ---       ┆ ---        │
│ str       ┆ f64        │
╞═══════════╪════════════╡
│ Montreal  ┆ 37.310934  │
│ Calgary   ┆ 37.592098  │
│ Toronto   ┆ 37.705746  │
│ Edmonton  ┆ 37.931609  │
│ Vancouver ┆ 38.011002  │
└───────────┴────────────┘
Query 4 completed in 0.017843s

Query 4:

        MATCH (p:Person)-[:LivesIn]->(ci:City)-[*1..2]->(country:Country)
        WHERE p.age > $age_lower AND p.age < $age_upper
        RETURN country.country AS countries, count(country) AS personCounts
        ORDER BY personCounts DESC LIMIT 3;

Persons between ages 30-40 in each country:
shape: (3, 2)
┌────────────────┬──────────────┐
│ countries      ┆ personCounts │
│ ---            ┆ ---          │
│ str            ┆ i64          │
╞════════════════╪══════════════╡
│ United States  ┆ 24983        │
│ Canada         ┆ 2514         │
│ United Kingdom ┆ 1498         │
└────────────────┴──────────────┘
Queries completed in 1.5745s
```