### PR TITLE
Add more queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KùzuDB: Benchmark study
 
-[Kùzu](https://kuzudb.com/) is an in-process (embedded) graph database management system (GDBMS). Because it is written in C++, it is blazing fast, and is optimized for handling complex join-heavy analytical workloads on very large graph databases. The database is under active development, but its philosophy is to become the "DuckDB of graph databases" -- a fast, lightweight, embeddable graph database for analytics use cases, with minimum setup and infrastructure effort.
+[Kùzu](https://kuzudb.com/) is an in-process (embedded) graph database management system (GDBMS). Because it is written in C++, it is blazing fast, and is optimized for handling complex join-heavy analytical workloads on very large graphs. The database is under active development, but its goal is to become the "DuckDB of graph databases" -- a fast, lightweight, embeddable graph database for analytics use cases, with minimal infrastructure setup effort.
 
 The goal of the code shown in this repo is as follows:
 
@@ -25,7 +25,7 @@ pip install -r requirements.txt
 
 ## Data
 
-An artificial social network dataset is used, generated via the [Faker](https://faker.readthedocs.io/en/master/) Python library.
+An artificial social network dataset is generated specifically for this exercise, via the [Faker](https://faker.readthedocs.io/en/master/) Python library.
 
 
 ### Generate all data at once

--- a/data/create_nodes_location.py
+++ b/data/create_nodes_location.py
@@ -55,7 +55,7 @@ def write_city_nodes(cities_of_interest: pl.DataFrame) -> pl.DataFrame:
     )
     # Add ID column to function as a primary key
     ids = list(range(1, len(city_nodes) + 1))
-    city_nodes = city_nodes.with_columns(pl.lit(ids).alias("id"))
+    city_nodes = city_nodes.with_columns(pl.Series(ids).alias("id"))
     # Write to csv
     city_nodes.select(pl.col("id"), pl.all().exclude("id")).write_csv(
         Path("output/nodes") / "cities.csv", separator="|"
@@ -69,7 +69,7 @@ def write_state_nodes(city_nodes: pl.DataFrame) -> None:
     state_nodes = city_nodes.select("state", "country").unique().sort(["country", "state"])
     # Add ID column to function as a primary key
     ids = list(range(1, len(state_nodes) + 1))
-    state_nodes = state_nodes.with_columns(pl.lit(ids).alias("id"))
+    state_nodes = state_nodes.with_columns(pl.Series(ids).alias("id"))
     # Write to csv
     state_nodes.select(pl.col("id"), pl.all().exclude("id")).write_csv(
         Path("output/nodes") / "states.csv", separator="|"
@@ -82,7 +82,7 @@ def write_country_nodes(city_nodes: pl.DataFrame) -> None:
     country_nodes = city_nodes.select("country").unique().sort("country", descending=False)
     # Add ID column to function as a primary key
     ids = list(range(1, len(country_nodes) + 1))
-    country_nodes = country_nodes.with_columns(pl.lit(ids).alias("id"))
+    country_nodes = country_nodes.with_columns(pl.Series(ids).alias("id"))
     # Write to csv
     country_nodes.select(pl.col("id"), pl.all().exclude("id")).write_csv(
         Path("output/nodes") / "countries.csv", separator="|"

--- a/kuzudb/README.md
+++ b/kuzudb/README.md
@@ -66,7 +66,7 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 1 completed in 0.242977s
+Query 1 completed in 0.338447s
 
 Query 2:
  
@@ -78,15 +78,14 @@ Query 2:
     
 City in which most-followed person lives:
 shape: (1, 5)
-┌────────┬──────────────┬────────┬───────┬───────────────┐
-│ name   ┆ numFollowers ┆ city   ┆ state ┆ country       │
-│ ---    ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
-│ str    ┆ i64          ┆ str    ┆ str   ┆ str           │
-╞════════╪══════════════╪════════╪═══════╪═══════════════╡
-│ Rachel ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
-│ Cooper ┆              ┆        ┆       ┆               │
-└────────┴──────────────┴────────┴───────┴───────────────┘
-Query 2 completed in 0.609420s
+┌───────────────┬──────────────┬────────┬───────┬───────────────┐
+│ name          ┆ numFollowers ┆ city   ┆ state ┆ country       │
+│ ---           ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
+│ str           ┆ i64          ┆ str    ┆ str   ┆ str           │
+╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
+│ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
+└───────────────┴──────────────┴────────┴───────┴───────────────┘
+Query 2 completed in 0.754088s
 
 Query 3:
  
@@ -107,7 +106,7 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.931609  │
 │ Vancouver ┆ 38.011002  │
 └───────────┴────────────┘
-Query 3 completed in 0.013523s
+Query 3 completed in 0.012301s
 
 Query 4:
  
@@ -127,7 +126,7 @@ shape: (3, 2)
 │ Canada         ┆ 2514         │
 │ United Kingdom ┆ 1498         │
 └────────────────┴──────────────┘
-Query 4 completed in 0.015331s
+Query 4 completed in 0.017814s
 
 Query 5:
  
@@ -148,7 +147,7 @@ shape: (1, 1)
 ╞════════════╡
 │ 52         │
 └────────────┘
-Query 5 completed in 0.011558s
+Query 5 completed in 0.012881s
 
 Query 6:
  
@@ -167,13 +166,13 @@ shape: (5, 3)
 │ ---        ┆ ---        ┆ ---            │
 │ i64        ┆ str        ┆ str            │
 ╞════════════╪════════════╪════════════════╡
-│ 66         ┆ Houston    ┆ United States  │
 │ 66         ┆ Birmingham ┆ United Kingdom │
+│ 66         ┆ Houston    ┆ United States  │
 │ 65         ┆ Raleigh    ┆ United States  │
 │ 64         ┆ Montreal   ┆ Canada         │
 │ 62         ┆ Phoenix    ┆ United States  │
 └────────────┴────────────┴────────────────┘
-Query 6 completed in 0.014809s
+Query 6 completed in 0.035519s
 
 Query 7:
  
@@ -196,7 +195,7 @@ shape: (1, 3)
 │ 169        ┆ California ┆ United States │
 └────────────┴────────────┴───────────────┘
             
-Query 7 completed in 0.010869s
+Query 7 completed in 0.014666s
 
 Query 8:
  
@@ -213,8 +212,8 @@ shape: (1, 1)
 ╞══════════════╡
 │ 1214477      │
 └──────────────┘
-Query 8 completed in 0.027979s
-Queries completed in 0.9553s
+Query 8 completed in 0.103491s
+Queries completed in 1.2895s
 ```
 
 ### Query performance
@@ -223,13 +222,13 @@ The numbers shown below are for when we ingest 100K person nodes, ~10K location 
 
 Summary of run times:
 
-* Query 1: `0.242977s`
-* Query 2: `0.609420s`
-* Query 3: `0.013523s`
-* Query 4: `0.015331s`
-* Query 5: `0.011558s`
-* Query 6: `0.014809s`
-* Query 7: `0.010869s`
-* Query 8: `0.027979s`
+* Query 1: `0.338447s`
+* Query 2: `0.754088s`
+* Query 3: `0.012301s`
+* Query 4: `0.017814s`
+* Query 5: `0.012881s`
+* Query 6: `0.035519s`
+* Query 7: `0.014666s`
+* Query 8: `0.103491s`
 
-> 💡 All queries (including materializing the results to arrow tables and then polars) take just under 1 sec 🔥 to complete (Neo4j takes over 4x longer). The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.
+> 💡 All queries (including materializing the results to arrow tables and then polars) take just over 1 sec 🔥 to complete (Neo4j takes over 4x longer). The timing shown is for queries run in a single execution thread on an M2 Macbook Pro with 16 GB of RAM.

--- a/kuzudb/README.md
+++ b/kuzudb/README.md
@@ -41,12 +41,14 @@ The following questions are asked of the graph:
 * **Query 2**: In which city does the most-followed person live?
 * **Query 3**: What are the top 5 cities with the lowest average age of persons?
 * **Query 4**: How many persons between ages 30-40 are there in each country?
+* **Query 5**: How many men in London, United Kingdom have an interest in fine dining?
+* **Query 6**: Which city has the maximum number of women that like Tennis?
+* **Query 7**: Which U.S. state has the maximum number of persons between the age 23-30 who enjoy photography?
+* **Query 8**: How many second degree connections are reachable in the graph?
 
 #### Output
 
 ```
-Query 1 completed in 0.471904s
-
 Query 1:
  
         MATCH (follower:Person)-[:Follows]->(person:Person)
@@ -64,7 +66,7 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 2 completed in 0.604744s
+Query 1 completed in 0.242977s
 
 Query 2:
  
@@ -84,7 +86,7 @@ shape: (1, 5)
 │ Rachel ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
 │ Cooper ┆              ┆        ┆       ┆               │
 └────────┴──────────────┴────────┴───────┴───────────────┘
-Query 3 completed in 0.013838s
+Query 2 completed in 0.609420s
 
 Query 3:
  
@@ -105,7 +107,7 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.931609  │
 │ Vancouver ┆ 38.011002  │
 └───────────┴────────────┘
-Query 4 completed in 0.017481s
+Query 3 completed in 0.013523s
 
 Query 4:
  
@@ -125,10 +127,95 @@ shape: (3, 2)
 │ Canada         ┆ 2514         │
 │ United Kingdom ┆ 1498         │
 └────────────────┴──────────────┘
-Queries completed in 1.1088s
-```
+Query 4 completed in 0.015331s
 
-As can be seen, Kùzu's results are identical to those obtained from Neo4j, while also being generated more than twice as quick.
+Query 5:
+ 
+        MATCH (p:Person)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        AND lower(p.gender) = lower($gender)
+        WITH p, i
+        MATCH (p)-[:LivesIn]->(c:City)
+        WHERE c.city = $city AND c.country = $country
+        RETURN count(p) AS numPersons
+    
+Number of male users in London, United Kingdom who have an interest in fine dining:
+shape: (1, 1)
+┌────────────┐
+│ numPersons │
+│ ---        │
+│ i64        │
+╞════════════╡
+│ 52         │
+└────────────┘
+Query 5 completed in 0.011558s
+
+Query 6:
+ 
+        MATCH (p:Person)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        AND p.gender = $gender
+        WITH p, i
+        MATCH (p)-[:LivesIn]->(c:City)
+        RETURN count(p.id) AS numPersons, c.city, c.country
+        ORDER BY numPersons DESC LIMIT 5
+    
+City with the most female users who have an interest in tennis:
+shape: (5, 3)
+┌────────────┬────────────┬────────────────┐
+│ numPersons ┆ c.city     ┆ c.country      │
+│ ---        ┆ ---        ┆ ---            │
+│ i64        ┆ str        ┆ str            │
+╞════════════╪════════════╪════════════════╡
+│ 66         ┆ Houston    ┆ United States  │
+│ 66         ┆ Birmingham ┆ United Kingdom │
+│ 65         ┆ Raleigh    ┆ United States  │
+│ 64         ┆ Montreal   ┆ Canada         │
+│ 62         ┆ Phoenix    ┆ United States  │
+└────────────┴────────────┴────────────────┘
+Query 6 completed in 0.014809s
+
+Query 7:
+ 
+        MATCH (p:Person)-[:LivesIn]->(:City)-[:CityIn]->(s:State)
+        WHERE p.age >= $age_lower AND p.age <= $age_upper AND s.country = $country
+        WITH p, s
+        MATCH (p)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        RETURN count(p.id) AS numPersons, s.state AS state, s.country AS country
+        ORDER BY numPersons DESC LIMIT 1
+    
+
+            State in United States with the most users between ages 23-30 who have an interest in photography:
+shape: (1, 3)
+┌────────────┬────────────┬───────────────┐
+│ numPersons ┆ state      ┆ country       │
+│ ---        ┆ ---        ┆ ---           │
+│ i64        ┆ str        ┆ str           │
+╞════════════╪════════════╪═══════════════╡
+│ 169        ┆ California ┆ United States │
+└────────────┴────────────┴───────────────┘
+            
+Query 7 completed in 0.010869s
+
+Query 8:
+ 
+        MATCH (p1:Person)-[f:Follows]->(p2:Person)
+        WHERE p1.id > p2.id
+        RETURN count(f) as numFollowers
+    
+Number of second degree connections reachable in the graph:
+shape: (1, 1)
+┌──────────────┐
+│ numFollowers │
+│ ---          │
+│ i64          │
+╞══════════════╡
+│ 1214477      │
+└──────────────┘
+Query 8 completed in 0.027979s
+Queries completed in 0.9553s
+```
 
 ### Query performance
 
@@ -136,9 +223,13 @@ The numbers shown below are for when we ingest 100K person nodes, ~10K location 
 
 Summary of run times:
 
-* Query 1: `0.471904s`
-* Query 2: `0.604744s`
-* Query 3: `0.013838s`
-* Query 4: `0.017481s`
+* Query 1: `0.242977s`
+* Query 2: `0.609420s`
+* Query 3: `0.013523s`
+* Query 4: `0.015331s`
+* Query 5: `0.011558s`
+* Query 6: `0.014809s`
+* Query 7: `0.010869s`
+* Query 8: `0.027979s`
 
-> 💡 All queries (including materializing the results to arrow tables and then polars) take just over 1 sec 🔥 to complete (Neo4j takes around 2x longer). Query 1 takes the longest to run -- around 0.5 sec. Queries 2 takes around 0.6 sec, and queries 3-4 are the fastest at ~0.15 sec. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.
+> 💡 All queries (including materializing the results to arrow tables and then polars) take just under 1 sec 🔥 to complete (Neo4j takes over 4x longer). The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -1,6 +1,7 @@
 """
 Run a series of queries on the Neo4j database
 """
+from pdb import run
 import polars as pl
 import kuzu
 from kuzu import Connection
@@ -15,11 +16,11 @@ def run_query1(conn: Connection) -> None:
         RETURN person.id AS personID, person.name AS name, count(follower.id) AS numFollowers
         ORDER BY numFollowers DESC LIMIT 3;
     """
+    print(f"\nQuery 1:\n {query}")
     with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
         response = conn.execute(query)
         result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-    print(f"\nQuery 1:\n {query}")
-    print(f"Top 3 most-followed persons:\n{result}")
+        print(f"Top 3 most-followed persons:\n{result}")
 
 
 def run_query2(conn: Connection) -> None:
@@ -31,11 +32,11 @@ def run_query2(conn: Connection) -> None:
         MATCH (person) -[:LivesIn]-> (city:City)
         RETURN person.name AS name, numFollowers, city.city AS city, city.state AS state, city.country AS country;
     """
+    print(f"\nQuery 2:\n {query}")
     with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
         response = conn.execute(query)
         result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-    print(f"\nQuery 2:\n {query}")
-    print(f"City in which most-followed person lives:\n{result}")
+        print(f"City in which most-followed person lives:\n{result}")
 
 
 def run_query3(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -45,11 +46,11 @@ def run_query3(conn: Connection, params: list[tuple[str, Any]]) -> None:
         RETURN c.city AS city, avg(p.age) AS averageAge
         ORDER BY averageAge LIMIT 5;
     """
+    print(f"\nQuery 3:\n {query}")
     with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
         response = conn.execute(query, parameters=params)
         result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-    print(f"\nQuery 3:\n {query}")
-    print(f"Cities with lowest average age in {params[0][1]}:\n{result}")
+        print(f"Cities with lowest average age in {params[0][1]}:\n{result}")
 
 
 def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -60,11 +61,82 @@ def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
         RETURN country.country AS countries, count(country) AS personCounts
         ORDER BY personCounts DESC LIMIT 3;
     """
+    print(f"\nQuery 4:\n {query}")
     with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
         response = conn.execute(query, parameters=params)
-    print(f"\nQuery 4:\n {query}")
-    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-    print(f"Persons between ages {params[0][1]}-{params[1][1]} in each country:\n{result}")
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+        print(f"Persons between ages {params[0][1]}-{params[1][1]} in each country:\n{result}")
+
+
+def run_query5(conn: Connection, params: list[tuple[str, Any]]) -> None:
+    "How many persons between a certain age range are in each country?"
+    query = """
+        MATCH (p:Person)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        AND lower(p.gender) = lower($gender)
+        WITH p, i
+        MATCH (p)-[:LivesIn]->(c:City)
+        WHERE c.city = $city AND c.country = $country
+        RETURN count(p) AS numPersons
+    """
+    print(f"\nQuery 5:\n {query}")
+    with Timer(name="query5", text="Query 5 completed in {:.6f}s"):
+        response = conn.execute(query, parameters=params)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+        print(f"Number of {params[0][1]} users in {params[1][1]}, {params[2][1]} who have an interest in {params[3][1]}:\n{result}")
+
+
+def run_query6(conn: Connection, params: list[tuple[str, Any]]) -> None:
+    "How many persons between a certain age range are in each country?"
+    query = """
+        MATCH (p:Person)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        AND p.gender = $gender
+        WITH p, i
+        MATCH (p)-[:LivesIn]->(c:City)
+        RETURN count(p.id) AS numPersons, c.city, c.country
+        ORDER BY numPersons DESC LIMIT 5
+    """
+    print(f"\nQuery 6:\n {query}")
+    with Timer(name="query6", text="Query 6 completed in {:.6f}s"):
+        response = conn.execute(query, parameters=params)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+        print(f"City with the most {params[0][1]} users who have an interest in {params[1][1]}:\n{result}")
+
+
+def run_query7(conn:Connection, params: list[tuple[str, Any]]) -> None:
+    "How many persons between a certain age range are in each country?"
+    query = """
+        MATCH (p:Person)-[:LivesIn]->(:City)-[:CityIn]->(s:State)
+        WHERE p.age >= $age_lower AND p.age <= $age_upper AND s.country = $country
+        WITH p, s
+        MATCH (p)-[:HasInterest]->(i:Interest)
+        WHERE lower(i.interest) = lower($interest)
+        RETURN count(p.id) AS numPersons, s.state AS state, s.country AS country
+        ORDER BY numPersons DESC LIMIT 1
+    """
+    print(f"\nQuery 7:\n {query}")
+    with Timer(name="query7", text="Query 7 completed in {:.6f}s"):
+        response = conn.execute(query, parameters=params)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+        print(
+            f"""
+            State in {params[0][1]} with the most users between ages {params[1][1]}-{params[2][1]} who have an interest in {params[3][1]}:\n{result}
+            """
+        )
+
+
+def run_query8(conn: Connection) -> None:
+    query = """
+        MATCH (p1:Person)-[f:Follows]->(p2:Person)
+        WHERE p1.id > p2.id
+        RETURN count(f) as numFollowers
+    """
+    print(f"\nQuery 8:\n {query}")
+    with Timer(name="query8", text="Query 8 completed in {:.6f}s"):
+        response = conn.execute(query)
+        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+        print(f"Number of second degree connections reachable in the graph:\n{result}")
 
 
 def main(conn: Connection) -> None:
@@ -73,6 +145,10 @@ def main(conn: Connection) -> None:
         run_query2(conn)
         run_query3(conn, params=[("country", "Canada")])
         run_query4(conn, params=[("age_lower", 30), ("age_upper", 40)])
+        run_query5(conn, params=[("gender", "male"), ("city", "London"), ("country", "United Kingdom"), ("interest", "fine dining")])
+        run_query6(conn, params=[("gender", "female"), ("interest", "tennis")])
+        run_query7(conn, params=[("country", "United States"), ("age_lower", 23), ("age_upper", 30), ("interest", "photography")])
+        run_query8(conn)
 
 
 if __name__ == "__main__":

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
     DB_NAME = "social_network"
     db = kuzu.Database(f"./{DB_NAME}")
     CONNECTION = kuzu.Connection(db)
+    CONNECTION.set_max_threads_for_exec(1)   # For a fairer comparison with Neo4j, where “Transactions are single-threaded, confined, and independent.”
 
     main(CONNECTION)
 

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -90,7 +90,7 @@ def run_query6(conn: Connection, params: list[tuple[str, Any]]) -> None:
     query = """
         MATCH (p:Person)-[:HasInterest]->(i:Interest)
         WHERE lower(i.interest) = lower($interest)
-        AND p.gender = $gender
+        AND lower(p.gender) = lower($gender)
         WITH p, i
         MATCH (p)-[:LivesIn]->(c:City)
         RETURN count(p.id) AS numPersons, c.city, c.country

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -1,7 +1,6 @@
 """
 Run a series of queries on the Neo4j database
 """
-from pdb import run
 import polars as pl
 import kuzu
 from kuzu import Connection

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -57,12 +57,14 @@ The following questions are asked of the graph:
 * **Query 2**: In which city does the most-followed person live?
 * **Query 3**: What are the top 5 cities with the lowest average age of persons?
 * **Query 4**: How many persons between ages 30-40 are there in each country?
+* **Query 5**: How many men in London, United Kingdom have an interest in fine dining?
+* **Query 6**: Which city has the maximum number of women that like Tennis?
+* **Query 7**: Which U.S. state has the maximum number of persons between the age 23-30 who enjoy photography?
+* **Query 8**: How many second degree connections are reachable in the graph?
 
 #### Output
 
 ```
-Query 1 completed in 1.880833s
-
 Query 1:
  
         MATCH (follower:Person)-[:FOLLOWS]->(person:Person)
@@ -80,7 +82,7 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 2 completed in 0.601604s
+Query 1 completed in 2.019171s
 
 Query 2:
  
@@ -92,15 +94,14 @@ Query 2:
     
 City in which most-followed person lives:
 shape: (1, 5)
-┌────────┬──────────────┬────────┬───────┬───────────────┐
-│ name   ┆ numFollowers ┆ city   ┆ state ┆ country       │
-│ ---    ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
-│ str    ┆ i64          ┆ str    ┆ str   ┆ str           │
-╞════════╪══════════════╪════════╪═══════╪═══════════════╡
-│ Rachel ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
-│ Cooper ┆              ┆        ┆       ┆               │
-└────────┴──────────────┴────────┴───────┴───────────────┘
-Query 3 completed in 0.059216s
+┌───────────────┬──────────────┬────────┬───────┬───────────────┐
+│ name          ┆ numFollowers ┆ city   ┆ state ┆ country       │
+│ ---           ┆ ---          ┆ ---    ┆ ---   ┆ ---           │
+│ str           ┆ i64          ┆ str    ┆ str   ┆ str           │
+╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
+│ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
+└───────────────┴──────────────┴────────┴───────┴───────────────┘
+Query 2 completed in 0.634306s
 
 Query 3:
  
@@ -121,7 +122,7 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.931609  │
 │ Vancouver ┆ 38.011002  │
 └───────────┴────────────┘
-Query 4 completed in 0.085356s
+Query 3 completed in 0.009135s
 
 Query 4:
  
@@ -141,7 +142,94 @@ shape: (3, 2)
 │ Canada         ┆ 2514         │
 │ United Kingdom ┆ 1498         │
 └────────────────┴──────────────┘
-Query script completed in 2.632767s
+Query 4 completed in 0.056189s
+
+Query 5:
+ 
+        MATCH (p:Person)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        AND tolower(p.gender) = tolower($gender)
+        WITH p, i
+        MATCH (p)-[:LIVES_IN]->(c:City)
+        WHERE c.city = $city AND c.country = $country
+        RETURN count(p) AS numPersons
+    
+Number of male users in London, United Kingdom who have an interest in fine dining:
+shape: (1, 1)
+┌────────────┐
+│ numPersons │
+│ ---        │
+│ i64        │
+╞════════════╡
+│ 52         │
+└────────────┘
+Query 5 completed in 0.010342s
+
+Query 6:
+ 
+        MATCH (p:Person)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        AND p.gender = $gender
+        WITH p, i
+        MATCH (p)-[:LIVES_IN]->(c:City)
+        RETURN count(p) AS numPersons, c.city, c.country
+        ORDER BY numPersons DESC LIMIT 5
+    
+City with the most female users who have an interest in tennis:
+shape: (5, 3)
+┌────────────┬────────────┬────────────────┐
+│ numPersons ┆ c.city     ┆ c.country      │
+│ ---        ┆ ---        ┆ ---            │
+│ i64        ┆ str        ┆ str            │
+╞════════════╪════════════╪════════════════╡
+│ 69         ┆ Houston    ┆ United States  │
+│ 68         ┆ Birmingham ┆ United Kingdom │
+│ 67         ┆ Raleigh    ┆ United States  │
+│ 64         ┆ Montreal   ┆ Canada         │
+│ 63         ┆ Phoenix    ┆ United States  │
+└────────────┴────────────┴────────────────┘
+Query 6 completed in 0.260219s
+
+Query 7:
+ 
+        MATCH (p:Person)-[:LIVES_IN]->(:City)-[:CITY_IN]->(s:State)
+        WHERE p.age >= $age_lower AND p.age <= $age_upper AND s.country = $country
+        WITH p, s
+        MATCH (p)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        RETURN count(p) AS numPersons, s.state AS state, s.country AS country
+        ORDER BY numPersons DESC LIMIT 1
+    
+
+            State in United States with the most users between ages 23-30 who have an interest in photography:
+shape: (1, 3)
+┌────────────┬────────────┬───────────────┐
+│ numPersons ┆ state      ┆ country       │
+│ ---        ┆ ---        ┆ ---           │
+│ i64        ┆ str        ┆ str           │
+╞════════════╪════════════╪═══════════════╡
+│ 172        ┆ California ┆ United States │
+└────────────┴────────────┴───────────────┘
+            
+Query 7 completed in 0.163613s
+
+Query 8:
+ 
+        MATCH (p1:Person)-[f:FOLLOWS]->(p2:Person)
+        WHERE p1.personID > p2.personID
+        RETURN count(f) as numFollowers
+    
+Number of second degree connections reachable in the graph:
+shape: (1, 1)
+┌──────────────┐
+│ numFollowers │
+│ ---          │
+│ i64          │
+╞══════════════╡
+│ 1219517      │
+└──────────────┘
+Query 8 completed in 0.990533s
+Query script completed in 4.144070s
 ```
 
 ### Query performance
@@ -150,9 +238,13 @@ The numbers shown below are for when we ingest 100K person nodes, ~10K location 
 
 Summary of run times:
 
-* Query 1: `1.880833s`
-* Query 2: `0.601604s`
-* Query 3: `0.059216s`
-* Query 4: `0.085356s`
+* Query1 : `2.019171s`
+* Query2 : `0.634306s`
+* Query3 : `0.009135s`
+* Query4 : `0.056189s`
+* Query5 : `0.010342s`
+* Query6 : `0.260219s`
+* Query7 : `0.163613s`
+* Query8 : `0.990533s`
 
-> 💡 All queries (including materializing the results to dict and then polars) take ~2.6 sec to complete. Query 1 takes the longest to run -- around 1.9 sec. Queries 2-4 take of the order of 0.6-0.8 sec. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.
+> 💡 All queries (including materializing the results to dict and then polars) take more than 4 sec to complete. The timing shown is for queries run on an M2 Macbook Pro with 16 GB of RAM.

--- a/neo4j/query.py
+++ b/neo4j/query.py
@@ -91,7 +91,7 @@ def run_query6(session: Session, gender: str, interest: str) -> None:
     query = """
         MATCH (p:Person)-[:HAS_INTEREST]->(i:Interest)
         WHERE tolower(i.interest) = tolower($interest)
-        AND p.gender = $gender
+        AND tolower(p.gender) = tolower($gender)
         WITH p, i
         MATCH (p)-[:LIVES_IN]->(c:City)
         RETURN count(p) AS numPersons, c.city, c.country

--- a/neo4j/query.py
+++ b/neo4j/query.py
@@ -16,21 +16,19 @@ NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
 
 
 def run_query1(session: Session) -> None:
-    "Who are the top 3 most-followed persons in the network?"
     query = """
         MATCH (follower:Person)-[:FOLLOWS]->(person:Person)
         RETURN person.personID AS personID, person.name AS name, count(follower) AS numFollowers
         ORDER BY numFollowers DESC LIMIT 3
     """
+    print(f"\nQuery 1:\n {query}")
     with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
         response = session.run(query)
         result = pl.from_dicts(response.data())
-    print(f"\nQuery 1:\n {query}")
-    print(f"Top 3 most-followed persons:\n{result}")
+        print(f"Top 3 most-followed persons:\n{result}")
 
 
 def run_query2(session: Session) -> None:
-    "In which city does the most-followed person in the network live?"
     query = """
         MATCH (follower:Person) -[:FOLLOWS]-> (person:Person)
         WITH person, count(follower) as followers
@@ -38,40 +36,106 @@ def run_query2(session: Session) -> None:
         MATCH (person) -[:LIVES_IN]-> (city:City)
         RETURN person.name AS name, followers AS numFollowers, city.city AS city, city.state AS state, city.country AS country
     """
+    print(f"\nQuery 2:\n {query}")
     with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
         response = session.run(query)
         result = pl.from_dicts(response.data())
-    print(f"\nQuery 2:\n {query}")
-    print(f"City in which most-followed person lives:\n{result}")
+        print(f"City in which most-followed person lives:\n{result}")
 
 
 def run_query3(session: Session, country: str) -> None:
-    "Which are the top 5 cities in a particular region of the world with the lowest average age in the network?"
     query = """
         MATCH (p:Person) -[:LIVES_IN]-> (c:City) -[*1..2]-> (co:Country {country: $country})
         RETURN c.city AS city, avg(p.age) AS averageAge
         ORDER BY averageAge LIMIT 5
     """
+    print(f"\nQuery 3:\n {query}")
     with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
         response = session.run(query, country=country)
         result = pl.from_dicts(response.data())
-    print(f"\nQuery 3:\n {query}")
-    print(f"Cities with lowest average age in {country}:\n{result}")
+        print(f"Cities with lowest average age in {country}:\n{result}")
 
 
 def run_query4(session: Session, age_lower: int, age_upper: int) -> None:
-    "How many persons between a certain age range are in each country?"
     query = """
         MATCH (p:Person)-[:LIVES_IN]->(ci:City)-[*1..2]->(country:Country)
         WHERE p.age > $age_lower AND p.age < $age_upper
         RETURN country.country AS countries, count(country) AS personCounts
         ORDER BY personCounts DESC LIMIT 3
     """
+    print(f"\nQuery 4:\n {query}")
     with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
         response = session.run(query, age_lower=age_lower, age_upper=age_upper)
         result = pl.from_dicts(response.data())
-    print(f"\nQuery 4:\n {query}")
-    print(f"Persons between ages {age_lower}-{age_upper} in each country:\n{result}")
+        print(f"Persons between ages {age_lower}-{age_upper} in each country:\n{result}")
+
+
+def run_query5(session: Session, gender: str, city: str, country: str, interest: str) -> None:
+    query = """
+        MATCH (p:Person)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        AND tolower(p.gender) = tolower($gender)
+        WITH p, i
+        MATCH (p)-[:LIVES_IN]->(c:City)
+        WHERE c.city = $city AND c.country = $country
+        RETURN count(p) AS numPersons
+    """
+    print(f"\nQuery 5:\n {query}")
+    with Timer(name="query5", text="Query 5 completed in {:.6f}s"):
+        response = session.run(query, gender=gender, city=city, country=country, interest=interest)
+        result = pl.from_dicts(response.data())
+        print(f"Number of {gender} users in {city}, {country} who have an interest in {interest}:\n{result}")
+
+
+def run_query6(session: Session, gender: str, interest: str) -> None:
+    query = """
+        MATCH (p:Person)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        AND p.gender = $gender
+        WITH p, i
+        MATCH (p)-[:LIVES_IN]->(c:City)
+        RETURN count(p) AS numPersons, c.city, c.country
+        ORDER BY numPersons DESC LIMIT 5
+    """
+    print(f"\nQuery 6:\n {query}")
+    with Timer(name="query6", text="Query 6 completed in {:.6f}s"):
+        response = session.run(query, gender=gender, interest=interest)
+        result = pl.from_dicts(response.data())
+        print(f"City with the most {gender} users who have an interest in {interest}:\n{result}")
+
+
+def run_query7(session: Session, country: str, age_lower: int, age_upper: int, interest: str) -> None:
+    query = """
+        MATCH (p:Person)-[:LIVES_IN]->(:City)-[:CITY_IN]->(s:State)
+        WHERE p.age >= $age_lower AND p.age <= $age_upper AND s.country = $country
+        WITH p, s
+        MATCH (p)-[:HAS_INTEREST]->(i:Interest)
+        WHERE tolower(i.interest) = tolower($interest)
+        RETURN count(p) AS numPersons, s.state AS state, s.country AS country
+        ORDER BY numPersons DESC LIMIT 1
+    """
+    print(f"\nQuery 7:\n {query}")
+    with Timer(name="query7", text="Query 7 completed in {:.6f}s"):
+        response = session.run(query, country=country, age_lower=age_lower, age_upper=age_upper, interest=interest)
+        result = pl.from_dicts(response.data())
+        print(
+            f"""
+            State in {country} with the most users between ages {age_lower}-{age_upper} who have an interest in {interest}:\n{result}
+            """
+        )
+
+
+def run_query8(session: Session) -> None:
+    query = """
+        MATCH (p1:Person)-[f:FOLLOWS]->(p2:Person)
+        WHERE p1.personID > p2.personID
+        RETURN count(f) as numFollowers
+    """
+    print(f"\nQuery 8:\n {query}")
+    with Timer(name="query8", text="Query 8 completed in {:.6f}s"):
+        response = session.run(query)
+        result = pl.from_dicts(response.data())
+        print(f"Number of second degree connections reachable in the graph:\n{result}")
 
 
 def main() -> None:
@@ -82,6 +146,10 @@ def main() -> None:
                 run_query2(session)
                 run_query3(session, country="Canada")
                 run_query4(session, age_lower=30, age_upper=40)
+                run_query5(session, gender="male", city="London", country="United Kingdom", interest="fine dining")
+                run_query6(session, gender="female", interest="tennis")
+                run_query7(session, country="United States", age_lower=23, age_upper=30, interest="photography")
+                run_query8(session)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 faker~=19.2.0
 polars~=0.18.0
+numpy>=1.25.0
+pyarrow~=12.0.0
 kuzu>=0.0.6
 neo4j~=5.11.0
 python-dotenv>=1.0.0
-codetiming~=1.4.0
+codetiming>=1.4.0


### PR DESCRIPTION
## Goals

Closes #14 if merged.

The aim of this PR is to run a broader suite of queries against Neo4j and Kùzu. It's clear that Kùzu has the potential to be massively faster than Neo4j at scale (for graphs that fit within memory or a single machine's disk).

In this PR, we add queries 5-8 that round up a suite of properties that a user may find interesting about the graph:

* **Query 1**: Who are the top 3 most-followed persons?
* **Query 2**: In which city does the most-followed person live?
* **Query 3**: What are the top 5 cities with the lowest average age of persons?
* **Query 4**: How many persons between ages 30-40 are there in each country?
* **Query 5**: How many men in London, United Kingdom have an interest in fine dining?
* **Query 6**: Which city has the maximum number of women that like Tennis?
* **Query 7**: Which U.S. state has the maximum number of persons between the age 23-30 who enjoy photography?
* **Query 8**: How many second degree person connections are reachable in the graph?

## Timing comparison

Query | Neo4j (sec) | Kùzu multi-thread (sec) | Speedup (Kùzu multi-thread) 
:---: | --- | ---: | ---: 
1 | 2.019171 | 0.242977 | 8.3 
2 | 0.634306 | 0.60942 | 1 
3 | 0.009135 | 0.013523 | 0.7 
4 | 0.056189 | 0.015331 | 3.7
5 | 0.010342 | 0.011558 | 0.9
6 | 0.260219 | 0.014809 | 17.6
7 | 0.163613 | 0.010869 | 15.1
8 | 0.990533 | 0.027979 | 35.4

Query | Neo4j (sec) |  Kùzu single-thread (sec) | Speedup (Kùzu single-thread)
:---: | --- | ---: | ---:
1 | 2.019171 | 0.338447 | 6.0
2 | 0.634306 | 0.754088 | 0.8
3 | 0.009135 | 0.012301 | 0.7
4 | 0.056189 | 0.017814 | 3.2
5 | 0.010342 | 0.012881 | 0.8
6 | 0.260219 | 0.035519 | 7.3
7 | 0.163613 | 0.014666 | 11.2
8 | 0.990533 | 0.103491 | 9.6

## Interesting observations

* It's immediately obvious that Kùzu is massively faster than Neo4j in queries 1, 4, 6, 7 and 8, where we are aggregating on the persons and interest nodes.
* Queries 2, 3 and 5 are interesting, because they involve *cities* and their relationships with persons, and in these cases Neo4j seems to perform faster than Kùzu. Why is this?
* Kùzu single-threaded query execution is also faster than Neo4j, in cases where the multi-threaded queries are faster than Neo4j -- so the reason for the "slowness" in queries 2, 3 and 5 run deeper than pure compute performance (it's likely to do with underlying query optimizations on 1-1 vs. many-many relationships in either DB).

## Problems

Queries 7 and 8 return inconsistent results between Kùzu and Neo4j. This needs to be investigated further as per #14.






