### PR TITLE
Update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # KùzuDB: Benchmark study
 
-[Kùzu](https://kuzudb.com/) is an in-process (embedded) graph database management system (GDBMS). Because it is written in C++, it is blazing fast, and is optimized for handling complex join-heavy analytical workloads on very large graphs. The database is under active development, but its goal is to become the "DuckDB of graph databases" -- a fast, lightweight, embeddable graph database for analytics use cases, with minimal infrastructure setup effort.
+[Kùzu](https://kuzudb.com/) is an in-process (embedded) graph database management system (GDBMS). Because it is written in C++, it is blazing fast, and is optimized for handling complex join-heavy analytical workloads on very large graphs. The database is under active development, but its goal is to become the "DuckDB of graph databases" -- a fast, lightweight, embeddable graph database for analytics (OLAP) use cases, with minimal setup time.
 
 The goal of the code shown in this repo is as follows:
 
 * Generate an artificial social network dataset, including persons, interests and locations
+  * It's quite easy to scale up the size of the artificial dataset using the scripts provided, so we can test the performance implications on larger graphs
 * Ingest the data into KùzuDB and Neo4j
 * Run a set of queries in Cypher on either DB to:
   * (1) Verify that the data is ingested correctly and that the results from either DB are consistent with one another
-  * (2) Benchmark the performance of Kùzu vs an established vendor like Neo4j
+  * (2) Benchmark the performance of Kùzu vs. an established vendor like Neo4j
 * Study the ingestion and query times for either DB, and optimize where possible
 
 Python is used as the intermediary language between the source data and the DBs.
@@ -58,62 +59,70 @@ The following questions are asked of both graphs:
 * **Query 5**: How many men in London, United Kingdom have an interest in fine dining?
 * **Query 6**: Which city has the maximum number of women that like Tennis?
 * **Query 7**: Which U.S. state has the maximum number of persons between the age 23-30 who enjoy photography?
-* **Query 8**: How many second degree connections are reachable in the graph?
+* **Query 8**: How many second-degree connections of persons are reachable in the graph?
 
 ## Performance comparison
 
 The run times for both ingestion and queries are compared.
 
-* For ingestion, KùzuDB is consistently faster than Neo4j by a factor of ~18x for a graph size of 100k nodes and ~2.4M edges.
-* For OLAP querying, **KùzuDB is significantly faster** than Neo4j for most types of queries, especially for ones that involve aggregating on many-many relationships.
+* For ingestion, KùzuDB is consistently faster than Neo4j by a factor of **~18x** for a graph size of 100K nodes and ~2.4M edges.
+* For OLAP queries, KùzuDB is **significantly faster** than Neo4j for most types of queries, especially for ones that involve aggregating on many-to-many relationships.
 
 ### Testing conditions
 
 * Macbook Pro M2, 16 GB RAM
-* All queries are run single-threaded (no parallelism)
+* All Neo4j queries are single-threaded as per their default configuration
 * Neo4j version: `5.10.0`
 * KùzuDB version: `0.7.0`
 * The run times reported are for the 5th run, because we want to allow the cache to warm up before gauging query performance
 
-
 ### Ingestion performance
 
+In total, ~100K nodes and ~2.5 million edges are ingested **~18x** faster in KùzuDB than in Neo4j.
+
 Case | Neo4j (sec) | Kùzu (sec) | Speedup factor
---- | --- | --- | ---
+--- | ---: | ---: | ---:
 Nodes | 3.6144 | 0.0874 | 41.4
 Edges | 37.5801 | 2.1622 | 17.4
 Total | 41.1945 | 2.2496 | 18.3
 
-In total, ~100K edges and ~2.5 million edges are ingested roughly 18x faster in KùzuDB than in Neo4j. Nodes are ingested significantly faster in Kùzu, and Neo4j's node ingestion remains of the order of seconds despite setting constraints on the ID fields as per their best practices. The speedup factors shown are expected to be even higher as the dataset gets larger and larger.
+Nodes are ingested significantly faster in Kùzu (of the order of milliseconds), and Neo4j's node ingestion remains of the order of seconds despite setting constraints on the ID fields as per their best practices. The speedup factors shown are expected to be even higher as the dataset gets larger and larger, with Kùzu being around two orders of magnitude faster for inserting nodes.
 
-### Query performance: (Kùzu single-threaded)
+### Query performance benchmark
+
+The full benchmark numbers are in the `README.md` pages for respective directories for `neo4j` and `kuzudb`.
+
+
+#### Neo4j vs. Kùzu single-threaded
+
+The following table shows the average run times for each query, and the speedup factor of Kùzu over Neo4j.
 
 Query | Neo4j (sec) | Kùzu (sec) | Speedup factor
---- | --- | --- | ---
-1 | 1.617523 | 0.311524 | 5.2
-2 | 0.592790 | 0.791726 | 0.7
-3 | 0.009398 | 0.012013 | 0.8
-4 | 0.047333 | 0.015932 | 3.0
-5 | 0.011949 | 0.012567 | 1.0
-6 | 0.024780 | 0.033764 | 0.7
-7 | 0.160752 | 0.012508 | 12.9
-8 | 0.845768 | 0.103470 | 8.2
+--- | ---: | ---: | ---:
+1 | 1.6641 | 0.1924749 | 8.6
+2 | 0.5808 | 0.6697257 | 0.9
+3 | 0.0052 | 0.0081793 | 0.6
+4 | 0.0464 | 0.0940350 | 0.5
+5 | 0.0064 | 0.0039781 | 1.6
+6 | 0.0183 | 0.0277400 | 0.7
+7 | 0.1539 | 0.0077988 | 19.7
+8 | 0.7275 | 0.0934627 | 7.8
 
-### Query performance: (Kùzu multi-threaded)
+#### Neo4j vs. Kùzu multi-threaded
 
 Unlike Neo4j, KùzuDB supports multi-threaded execution of queries. The following results are for the same queries as above, but allowing Kùzu to choose the optimal number of threads for each query.
 
 Query | Neo4j (sec) | Kùzu (sec) | Speedup factor
---- | --- | --- | ---
-1 | 1.617523 | 0.230980 | 7.0
-2 | 0.592790 | 0.625935 | 0.9
-3 | 0.009398 | 0.011896 | 0.8
-4 | 0.047333 | 0.014518 | 3.3
-5 | 0.011949 | 0.012230 | 1.0
-6 | 0.024780 | 0.015304 | 1.6
-7 | 0.160752 | 0.010679 | 15.1
-8 | 0.845768 | 0.024422 | 34.6
+--- | ---: | ---: | ---:
+1 | 1.6641 | 0.1255608 | 13.3
+2 | 0.5808 | 0.5778111 | 1.0
+3 | 0.0052 | 0.0074214 | 0.7
+4 | 0.0464 | 0.0085207 | 5.4
+5 | 0.0064 | 0.0048872 | 1.3
+6 | 0.0183 | 0.0124077 | 1.5
+7 | 0.1539 | 0.0068174 | 22.6
+8 | 0.7275 | 0.0211530 | 34.4
 
-Some queries show as much as a 34x speedup over Neo4j, and the average speedup is 7.5x.
+> 🔥 The second-degree path finding query (8) shows a **~34x** speedup over Neo4j for the 100K node, 2.4M edge graph, and the average speedup across all queries when using Kùzu is **~8.5x**.
 
-It would be interesting to further study the cases where Kùzu's performance is more in line with Neo4j. More to come soon!
+It would be interesting to further study the cases where Kùzu's performance is on par with Neo4j. More to come soon!

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ Nodes are ingested significantly faster in Kùzu (of the order of milliseconds),
 
 ### Query performance benchmark
 
-The full benchmark numbers are in the `README.md` pages for respective directories for `neo4j` and `kuzudb`.
-
+The full benchmark numbers are in the `README.md` pages for respective directories for `neo4j` and `kuzudb`. The benchmarks are run via the `pytest-benchmark` library directly from each directory for the queries on either DB.
 
 #### Neo4j vs. Kùzu single-threaded
 

--- a/kuzudb/README.md
+++ b/kuzudb/README.md
@@ -267,7 +267,6 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 1 completed in 0.230980s
 
 Query 2:
  
@@ -286,7 +285,6 @@ shape: (1, 5)
 ╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
 │ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
 └───────────────┴──────────────┴────────┴───────┴───────────────┘
-Query 2 completed in 0.625935s
 
 Query 3:
  
@@ -307,7 +305,6 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.943678  │
 │ Vancouver ┆ 38.023227  │
 └───────────┴────────────┘
-Query 3 completed in 0.011896s
 
 Query 4:
  
@@ -327,7 +324,6 @@ shape: (3, 2)
 │ Canada         ┆ 3064         │
 │ United Kingdom ┆ 1873         │
 └────────────────┴──────────────┘
-Query 4 completed in 0.014518s
 
 Query 5:
  
@@ -348,7 +344,6 @@ shape: (1, 1)
 ╞════════════╡
 │ 52         │
 └────────────┘
-Query 5 completed in 0.012230s
 
 Query 6:
  
@@ -357,13 +352,13 @@ Query 6:
         AND lower(p.gender) = lower($gender)
         WITH p, i
         MATCH (p)-[:LivesIn]->(c:City)
-        RETURN count(p.id) AS numPersons, c.city, c.country
+        RETURN count(p.id) AS numPersons, c.city AS city, c.country AS country
         ORDER BY numPersons DESC LIMIT 5
     
 City with the most female users who have an interest in tennis:
 shape: (5, 3)
 ┌────────────┬────────────┬────────────────┐
-│ numPersons ┆ c.city     ┆ c.country      │
+│ numPersons ┆ city       ┆ country        │
 │ ---        ┆ ---        ┆ ---            │
 │ i64        ┆ str        ┆ str            │
 ╞════════════╪════════════╪════════════════╡
@@ -373,7 +368,6 @@ shape: (5, 3)
 │ 64         ┆ Montreal   ┆ Canada         │
 │ 62         ┆ Phoenix    ┆ United States  │
 └────────────┴────────────┴────────────────┘
-Query 6 completed in 0.015304s
 
 Query 7:
  
@@ -386,7 +380,7 @@ Query 7:
         ORDER BY numPersons DESC LIMIT 1
     
 
-            State in United States with the most users between ages 23-30 who have an interest in photography:
+        State in United States with the most users between ages 23-30 who have an interest in photography:
 shape: (1, 3)
 ┌────────────┬────────────┬───────────────┐
 │ numPersons ┆ state      ┆ country       │
@@ -395,8 +389,7 @@ shape: (1, 3)
 ╞════════════╪════════════╪═══════════════╡
 │ 170        ┆ California ┆ United States │
 └────────────┴────────────┴───────────────┘
-            
-Query 7 completed in 0.010679s
+        
 
 Query 8:
  
@@ -413,17 +406,74 @@ shape: (1, 1)
 ╞══════════════╡
 │ 1214477      │
 └──────────────┘
-Query 8 completed in 0.024422s
-Queries completed in 0.9465s
+Queries completed in 1.2756s
+```
+
+#### Query performance benchmark (Kùzu single-threaded)
+
+The benchmark is run using `pytest-benchmark` package as follows.
+
+```sh
+$ pytest benchmark_query.py --benchmark-min-rounds=5 --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-sort=fullname
+==================================================================================== test session starts =====================================================================================
+platform darwin -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
+benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=True min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=5)
+rootdir: /code/kuzudb-study/kuzudb
+plugins: Faker-19.2.0, anyio-3.7.1, benchmark-4.0.0
+collected 8 items
+
+benchmark_query.py ........                                                                                                                                                            [100%]
+
+
+-------------------------------------------------------------------------------------- benchmark: 8 tests --------------------------------------------------------------------------------------
+Name (time in ms)              Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_query1     187.4783 (50.09)    208.4892 (45.44)    192.4749 (48.38)     8.9712 (54.05)    188.8628 (47.85)     5.4620 (58.77)         1;1    5.1955 (0.02)          5           1
+test_benchmark_query2     651.9378 (174.18)   727.6718 (158.61)   669.7257 (168.35)   32.5196 (195.93)   656.0755 (166.22)   23.4683 (252.52)        1;1    1.4931 (0.01)          5           1
+test_benchmark_query3       7.1727 (1.92)      16.3433 (3.56)       8.1793 (2.06)      1.1808 (7.11)       7.9322 (2.01)      0.4850 (5.22)          7;7  122.2596 (0.49)         78           1
+test_benchmark_query4       8.5364 (2.28)      11.1066 (2.42)       9.4035 (2.36)      0.8492 (5.12)       8.9223 (2.26)      1.1856 (12.76)        12;0  106.3432 (0.42)         49           1
+test_benchmark_query5       3.7428 (1.0)        4.5879 (1.0)        3.9781 (1.0)       0.1660 (1.0)        3.9471 (1.0)       0.0929 (1.0)           5;4  251.3782 (1.0)          48           1
+test_benchmark_query6      25.9462 (6.93)      33.3162 (7.26)      27.7400 (6.97)      1.2350 (7.44)      27.4689 (6.96)      0.8201 (8.82)          4;4   36.0490 (0.14)         36           1
+test_benchmark_query7       6.9201 (1.85)       8.6525 (1.89)       7.7988 (1.96)      0.3281 (1.98)       7.7646 (1.97)      0.1844 (1.98)        18;16  128.2242 (0.51)         69           1
+test_benchmark_query8      90.1384 (24.08)    108.3035 (23.61)     93.4627 (23.49)     5.1808 (31.21)     91.7108 (23.23)     2.1502 (23.14)         1;1   10.6995 (0.04)         11           1
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+===================================================================================== 8 passed in 11.92s =====================================================================================
 ```
 
 #### Query performance (Kùzu multi-threaded)
 
-* Query 1: `0.230980s`
-* Query 2: `0.625935s`
-* Query 3: `0.011896s`
-* Query 4: `0.014518s`
-* Query 5: `0.012230s`
-* Query 6: `0.015304s`
-* Query 7: `0.010679s`
-* Query 8: `0.024422s`
+```sh
+$ pytest benchmark_query.py --benchmark-min-rounds=5 --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-sort=fullname
+==================================================================================== test session starts =====================================================================================
+platform darwin -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
+benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=True min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=5)
+rootdir: /code/kuzudb-study/kuzudb
+plugins: Faker-19.2.0, anyio-3.7.1, benchmark-4.0.0
+collected 8 items
+
+benchmark_query.py ........                                                                                                                                                            [100%]
+
+
+-------------------------------------------------------------------------------------- benchmark: 8 tests --------------------------------------------------------------------------------------
+Name (time in ms)              Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_query1     112.4209 (29.98)    175.6500 (27.58)    125.5608 (25.69)    28.0081 (63.91)    112.8987 (22.96)    16.8425 (32.06)         1;1    7.9643 (0.04)          5           1
+test_benchmark_query2     571.3696 (152.38)   586.1770 (92.03)    577.8111 (118.23)    5.9532 (13.58)    575.7557 (117.08)    9.1151 (17.35)         2;0    1.7307 (0.01)          5           1
+test_benchmark_query3       6.4611 (1.72)       8.9117 (1.40)       7.4214 (1.52)      0.6558 (1.50)       7.4137 (1.51)      1.3337 (2.54)         48;0  134.7447 (0.66)         98           1
+test_benchmark_query4       6.6348 (1.77)      10.0138 (1.57)       8.5207 (1.74)      0.5462 (1.25)       8.5367 (1.74)      0.5669 (1.08)         13;2  117.3612 (0.57)         67           1
+test_benchmark_query5       3.7497 (1.0)        6.3695 (1.0)        4.8872 (1.0)       0.4716 (1.08)       4.9178 (1.0)       0.6603 (1.26)         21;1  204.6181 (1.0)          70           1
+test_benchmark_query6      11.1365 (2.97)      14.3319 (2.25)      12.4077 (2.54)      0.7140 (1.63)      12.3383 (2.51)      0.7948 (1.51)         15;5   80.5951 (0.39)         61           1
+test_benchmark_query7       5.8870 (1.57)       8.2347 (1.29)       6.8174 (1.39)      0.4641 (1.06)       6.7216 (1.37)      0.6434 (1.22)         32;1  146.6837 (0.72)        103           1
+test_benchmark_query8      20.4635 (5.46)      22.2344 (3.49)      21.1153 (4.32)      0.4383 (1.0)       21.0030 (4.27)      0.5253 (1.0)          10;1   47.3590 (0.23)         36           1
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+===================================================================================== 8 passed in 10.22s =====================================================================================
+```
+

--- a/kuzudb/benchmark_query.py
+++ b/kuzudb/benchmark_query.py
@@ -1,0 +1,134 @@
+"""
+Use the `pytest-benchmark` library to more formally benchmark the Neo4j queries wiht warmup and iterations.
+`pip install pytest-benchmark`
+"""
+import os
+
+import pytest
+from dotenv import load_dotenv
+import kuzu
+from kuzu import Connection
+
+import query
+
+load_dotenv()
+
+
+@pytest.fixture(scope="session")
+def connection():
+    db = kuzu.Database(f"./social_network")
+    conn = kuzu.Connection(db)
+    # For a fairer comparison with Neo4j, where “Transactions are single-threaded, confined, and independent.”
+    conn.set_max_threads_for_exec(1)
+    yield conn
+
+
+def test_benchmark_query1(benchmark, connection):
+    result = benchmark(query.run_query1, connection)
+    result = result.to_dicts()
+
+    assert len(result) == 3
+    assert result[0]["personID"] == 85723
+    assert result[1]["personID"] == 68753
+    assert result[2]["personID"] == 54696
+    assert result[0]["numFollowers"] == 4998
+    assert result[1]["numFollowers"] == 4985
+    assert result[2]["numFollowers"] == 4976
+
+
+def test_benchmark_query2(benchmark, connection):
+    result = benchmark(query.run_query2, connection)
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "Rachel Cooper"
+    assert result[0]["numFollowers"] == 4998
+    assert result[0]["city"] == "Austin"
+    assert result[0]["state"] == "Texas"
+    assert result[0]["country"] == "United States"
+
+
+def test_benchmark_query3(benchmark, connection):
+    result = benchmark(query.run_query3, connection, [("country", "Canada")])
+    result = result.to_dicts()
+
+    assert len(result) == 5
+    assert result[0]["city"] == "Montreal"
+    assert result[1]["city"] == "Calgary"
+    assert result[2]["city"] == "Toronto"
+    assert result[3]["city"] == "Edmonton"
+    assert result[4]["city"] == "Vancouver"
+
+
+def test_benchmark_query4(benchmark, connection):
+    result = benchmark(query.run_query4, connection, [("age_lower", 30), ("age_upper", 40)])
+    result = result.to_dicts()
+
+    assert len(result) == 3
+    assert result[0]["countries"] == "United States"
+    assert result[1]["countries"] == "Canada"
+    assert result[2]["countries"] == "United Kingdom"
+    assert result[0]["personCounts"] == 30473
+    assert result[1]["personCounts"] == 3064
+    assert result[2]["personCounts"] == 1873
+
+
+def test_benchmark_query5(benchmark, connection):
+    result = benchmark(
+        query.run_query5,
+        connection,
+        [
+            ("gender", "male"),
+            ("city", "London"),
+            ("country", "United Kingdom"),
+            ("interest", "fine dining"),
+        ],
+    )
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numPersons"] == 52
+
+
+def test_benchmark_query6(benchmark, connection):
+    result = benchmark(
+        query.run_query6,
+        connection,
+        [
+            ("gender", "female"),
+            ("interest", "tennis")
+        ],
+    )
+    result = result.to_dicts()
+
+    assert len(result) == 5
+    assert result[0]["numPersons"] == 66
+    assert result[0]["city"] in ("Houston", "Birmingham")
+    assert result[0]["country"] in ("United States", "United Kingdom")
+
+
+def test_benchmark_query7(benchmark, connection):
+    result = benchmark(
+        query.run_query7,
+        connection,
+        [
+            ("country", "United States"),
+            ("age_lower", 23),
+            ("age_upper", 30),
+            ("interest", "photography"),
+        ],
+    )
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numPersons"] == 170
+    assert result[0]["state"] == "California"
+    assert result[0]["country"] == "United States"
+
+
+def test_benchmark_query8(benchmark, connection):
+    result = benchmark(query.run_query8, connection)
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numFollowers"] == 1214477

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -17,10 +17,10 @@ def run_query1(conn: Connection) -> None:
         ORDER BY numFollowers DESC LIMIT 3;
     """
     print(f"\nQuery 1:\n {query}")
-    with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
-        response = conn.execute(query)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(f"Top 3 most-followed persons:\n{result}")
+    response = conn.execute(query)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(f"Top 3 most-followed persons:\n{result}")
+    return result
 
 
 def run_query2(conn: Connection) -> None:
@@ -33,10 +33,10 @@ def run_query2(conn: Connection) -> None:
         RETURN person.name AS name, numFollowers, city.city AS city, city.state AS state, city.country AS country;
     """
     print(f"\nQuery 2:\n {query}")
-    with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
-        response = conn.execute(query)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(f"City in which most-followed person lives:\n{result}")
+    response = conn.execute(query)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(f"City in which most-followed person lives:\n{result}")
+    return result
 
 
 def run_query3(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -47,10 +47,10 @@ def run_query3(conn: Connection, params: list[tuple[str, Any]]) -> None:
         ORDER BY averageAge LIMIT 5;
     """
     print(f"\nQuery 3:\n {query}")
-    with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
-        response = conn.execute(query, parameters=params)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(f"Cities with lowest average age in {params[0][1]}:\n{result}")
+    response = conn.execute(query, parameters=params)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(f"Cities with lowest average age in {params[0][1]}:\n{result}")
+    return result
 
 
 def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -62,10 +62,10 @@ def run_query4(conn: Connection, params: list[tuple[str, Any]]) -> None:
         ORDER BY personCounts DESC LIMIT 3;
     """
     print(f"\nQuery 4:\n {query}")
-    with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
-        response = conn.execute(query, parameters=params)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(f"Persons between ages {params[0][1]}-{params[1][1]} in each country:\n{result}")
+    response = conn.execute(query, parameters=params)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(f"Persons between ages {params[0][1]}-{params[1][1]} in each country:\n{result}")
+    return result
 
 
 def run_query5(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -80,12 +80,12 @@ def run_query5(conn: Connection, params: list[tuple[str, Any]]) -> None:
         RETURN count(p) AS numPersons
     """
     print(f"\nQuery 5:\n {query}")
-    with Timer(name="query5", text="Query 5 completed in {:.6f}s"):
-        response = conn.execute(query, parameters=params)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(
-            f"Number of {params[0][1]} users in {params[1][1]}, {params[2][1]} who have an interest in {params[3][1]}:\n{result}"
-        )
+    response = conn.execute(query, parameters=params)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(
+        f"Number of {params[0][1]} users in {params[1][1]}, {params[2][1]} who have an interest in {params[3][1]}:\n{result}"
+    )
+    return result
 
 
 def run_query6(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -96,16 +96,16 @@ def run_query6(conn: Connection, params: list[tuple[str, Any]]) -> None:
         AND lower(p.gender) = lower($gender)
         WITH p, i
         MATCH (p)-[:LivesIn]->(c:City)
-        RETURN count(p.id) AS numPersons, c.city, c.country
+        RETURN count(p.id) AS numPersons, c.city AS city, c.country AS country
         ORDER BY numPersons DESC LIMIT 5
     """
     print(f"\nQuery 6:\n {query}")
-    with Timer(name="query6", text="Query 6 completed in {:.6f}s"):
-        response = conn.execute(query, parameters=params)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(
-            f"City with the most {params[0][1]} users who have an interest in {params[1][1]}:\n{result}"
-        )
+    response = conn.execute(query, parameters=params)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(
+        f"City with the most {params[0][1]} users who have an interest in {params[1][1]}:\n{result}"
+    )
+    return result
 
 
 def run_query7(conn: Connection, params: list[tuple[str, Any]]) -> None:
@@ -120,14 +120,14 @@ def run_query7(conn: Connection, params: list[tuple[str, Any]]) -> None:
         ORDER BY numPersons DESC LIMIT 1
     """
     print(f"\nQuery 7:\n {query}")
-    with Timer(name="query7", text="Query 7 completed in {:.6f}s"):
-        response = conn.execute(query, parameters=params)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(
-            f"""
-            State in {params[0][1]} with the most users between ages {params[1][1]}-{params[2][1]} who have an interest in {params[3][1]}:\n{result}
-            """
-        )
+    response = conn.execute(query, parameters=params)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(
+        f"""
+        State in {params[0][1]} with the most users between ages {params[1][1]}-{params[2][1]} who have an interest in {params[3][1]}:\n{result}
+        """
+    )
+    return result
 
 
 def run_query8(conn: Connection) -> None:
@@ -137,19 +137,19 @@ def run_query8(conn: Connection) -> None:
         RETURN count(f) as numFollowers
     """
     print(f"\nQuery 8:\n {query}")
-    with Timer(name="query8", text="Query 8 completed in {:.6f}s"):
-        response = conn.execute(query)
-        result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
-        print(f"Number of second degree connections reachable in the graph:\n{result}")
+    response = conn.execute(query)
+    result = pl.from_arrow(response.get_as_arrow(chunk_size=1000))
+    print(f"Number of second degree connections reachable in the graph:\n{result}")
+    return result
 
 
 def main(conn: Connection) -> None:
     with Timer(name="queries", text="Queries completed in {:.4f}s"):
-        run_query1(conn)
-        run_query2(conn)
-        run_query3(conn, params=[("country", "Canada")])
-        run_query4(conn, params=[("age_lower", 30), ("age_upper", 40)])
-        run_query5(
+        _ = run_query1(conn)
+        _ = run_query2(conn)
+        _ = run_query3(conn, params=[("country", "Canada")])
+        _ = run_query4(conn, params=[("age_lower", 30), ("age_upper", 40)])
+        _ = run_query5(
             conn,
             params=[
                 ("gender", "male"),
@@ -158,8 +158,8 @@ def main(conn: Connection) -> None:
                 ("interest", "fine dining"),
             ],
         )
-        run_query6(conn, params=[("gender", "female"), ("interest", "tennis")])
-        run_query7(
+        _ = run_query6(conn, params=[("gender", "female"), ("interest", "tennis")])
+        _ = run_query7(
             conn,
             params=[
                 ("country", "United States"),
@@ -168,7 +168,7 @@ def main(conn: Connection) -> None:
                 ("interest", "photography"),
             ],
         )
-        run_query8(conn)
+        _ = run_query8(conn)
 
 
 if __name__ == "__main__":

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -87,7 +87,6 @@ shape: (3, 3)
 │ 68753    ┆ Claudia Booker ┆ 4985         │
 │ 54696    ┆ Brian Burgess  ┆ 4976         │
 └──────────┴────────────────┴──────────────┘
-Query 1 completed in 1.617523s
 
 Query 2:
  
@@ -106,7 +105,6 @@ shape: (1, 5)
 ╞═══════════════╪══════════════╪════════╪═══════╪═══════════════╡
 │ Rachel Cooper ┆ 4998         ┆ Austin ┆ Texas ┆ United States │
 └───────────────┴──────────────┴────────┴───────┴───────────────┘
-Query 2 completed in 0.592790s
 
 Query 3:
  
@@ -127,7 +125,6 @@ shape: (5, 2)
 │ Edmonton  ┆ 37.943678  │
 │ Vancouver ┆ 38.023227  │
 └───────────┴────────────┘
-Query 3 completed in 0.009398s
 
 Query 4:
  
@@ -147,7 +144,6 @@ shape: (3, 2)
 │ Canada         ┆ 3064         │
 │ United Kingdom ┆ 1873         │
 └────────────────┴──────────────┘
-Query 4 completed in 0.047333s
 
 Query 5:
  
@@ -168,7 +164,6 @@ shape: (1, 1)
 ╞════════════╡
 │ 52         │
 └────────────┘
-Query 5 completed in 0.011949s
 
 Query 6:
  
@@ -177,13 +172,13 @@ Query 6:
         AND tolower(p.gender) = tolower($gender)
         WITH p, i
         MATCH (p)-[:LIVES_IN]->(c:City)
-        RETURN count(p) AS numPersons, c.city, c.country
+        RETURN count(p) AS numPersons, c.city AS city, c.country AS country
         ORDER BY numPersons DESC LIMIT 5
     
-City with the most female users who have an interest in tennis:
+Cities with the most female users who have an interest in tennis:
 shape: (5, 3)
 ┌────────────┬────────────┬────────────────┐
-│ numPersons ┆ c.city     ┆ c.country      │
+│ numPersons ┆ city       ┆ country        │
 │ ---        ┆ ---        ┆ ---            │
 │ i64        ┆ str        ┆ str            │
 ╞════════════╪════════════╪════════════════╡
@@ -193,7 +188,6 @@ shape: (5, 3)
 │ 64         ┆ Montreal   ┆ Canada         │
 │ 62         ┆ Phoenix    ┆ United States  │
 └────────────┴────────────┴────────────────┘
-Query 6 completed in 0.024780s
 
 Query 7:
  
@@ -206,7 +200,7 @@ Query 7:
         ORDER BY numPersons DESC LIMIT 1
     
 
-            State in United States with the most users between ages 23-30 who have an interest in photography:
+        State in United States with the most users between ages 23-30 who have an interest in photography:
 shape: (1, 3)
 ┌────────────┬────────────┬───────────────┐
 │ numPersons ┆ state      ┆ country       │
@@ -215,8 +209,7 @@ shape: (1, 3)
 ╞════════════╪════════════╪═══════════════╡
 │ 170        ┆ California ┆ United States │
 └────────────┴────────────┴───────────────┘
-            
-Query 7 completed in 0.160752s
+        
 
 Query 8:
  
@@ -233,21 +226,41 @@ shape: (1, 1)
 ╞══════════════╡
 │ 1214477      │
 └──────────────┘
-Query 8 completed in 0.845768s
-Query script completed in 3.310654s
+Neo4j query script completed in 3.344930s
 ```
 
-### Query performance
+### Query performance benchmark
 
-The numbers shown below are for when we ingest 100K person nodes, ~10K location nodes and ~2.4M edges into the graph. Query times for simple aggregation and path finding are relatively low. More advanced queries involving variable length paths will be studied later.
+The benchmark is run using `pytest-benchmark` package as follows.
 
-Summary of run times:
+```sh
+$ pytest benchmark_query.py --benchmark-min-rounds=5 --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-sort=fullname
+==================================================================================== test session starts =====================================================================================
+platform darwin -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
+benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=True min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=5)
+rootdir: /code/kuzudb-study/neo4j
+plugins: Faker-19.2.0, anyio-3.7.1, benchmark-4.0.0
+collected 8 items
 
-* Query1 : `1.617523s`
-* Query2 : `0.592790s`
-* Query3 : `0.009398s`
-* Query4 : `0.047333s`
-* Query5 : `0.011949s`
-* Query6 : `0.024780s`
-* Query7 : `0.160752s`
-* Query8 : `0.845768s`
+benchmark_query.py ........                                                                                                                                                            [100%]
+
+
+--------------------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------------------
+Name (time in s)             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_query1     1.6268 (389.74)   1.7258 (221.08)   1.6641 (322.43)   0.0378 (117.01)   1.6501 (344.53)   0.0416 (97.74)         1;0    0.6009 (0.00)          5           1
+test_benchmark_query2     0.5706 (136.71)   0.5875 (75.27)    0.5808 (112.54)   0.0074 (22.88)    0.5844 (122.01)   0.0122 (28.67)         1;0    1.7217 (0.01)          5           1
+test_benchmark_query3     0.0042 (1.0)      0.0131 (1.67)     0.0052 (1.0)      0.0015 (4.54)     0.0048 (1.0)      0.0006 (1.40)          6;8  193.7594 (1.0)         106           1
+test_benchmark_query4     0.0395 (9.46)     0.0562 (7.20)     0.0464 (8.99)     0.0056 (17.23)    0.0436 (9.11)     0.0108 (25.24)         9;0   21.5463 (0.11)         21           1
+test_benchmark_query5     0.0058 (1.39)     0.0078 (1.0)      0.0064 (1.24)     0.0003 (1.0)      0.0063 (1.31)     0.0004 (1.0)          25;2  156.8681 (0.81)         97           1
+test_benchmark_query6     0.0155 (3.71)     0.0221 (2.83)     0.0183 (3.55)     0.0015 (4.77)     0.0181 (3.79)     0.0021 (4.89)         11;0   54.6242 (0.28)         46           1
+test_benchmark_query7     0.1512 (36.23)    0.1578 (20.21)    0.1539 (29.83)    0.0022 (6.86)     0.1532 (31.98)    0.0027 (6.37)          2;0    6.4960 (0.03)          7           1
+test_benchmark_query8     0.7210 (172.74)   0.7335 (93.97)    0.7275 (140.95)   0.0046 (14.31)    0.7283 (152.06)   0.0058 (13.65)         2;0    1.3746 (0.01)          5           1
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+===================================================================================== 8 passed in 26.73s =====================================================================================
+
+```

--- a/neo4j/benchmark_query.py
+++ b/neo4j/benchmark_query.py
@@ -1,0 +1,109 @@
+"""
+Use the `pytest-benchmark` library to more formally benchmark the Neo4j queries wiht warmup and iterations.
+`pip install pytest-benchmark`
+"""
+import os
+
+import pytest
+from dotenv import load_dotenv
+from neo4j import GraphDatabase
+
+import query
+
+load_dotenv()
+
+
+@pytest.fixture(scope="session")
+def session():
+    URI = "bolt://localhost:7687"
+    NEO4J_USER = os.environ.get("NEO4J_USER")
+    NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
+    with GraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD)) as driver:
+        with driver.session(database="neo4j") as session:
+            yield session
+
+
+def test_benchmark_query1(benchmark, session):
+    result = benchmark(query.run_query1, session)
+    result = result.to_dicts()
+
+    assert len(result) == 3
+    assert result[0]["personID"] == 85723
+    assert result[1]["personID"] == 68753
+    assert result[2]["personID"] == 54696
+    assert result[0]["numFollowers"] == 4998
+    assert result[1]["numFollowers"] == 4985
+    assert result[2]["numFollowers"] == 4976
+
+
+def test_benchmark_query2(benchmark, session):
+    result = benchmark(query.run_query2, session)
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "Rachel Cooper"
+    assert result[0]["numFollowers"] == 4998
+    assert result[0]["city"] == "Austin"
+    assert result[0]["state"] == "Texas"
+    assert result[0]["country"] == "United States"
+
+
+def test_benchmark_query3(benchmark, session):
+    result = benchmark(query.run_query3, session, "Canada")
+    result = result.to_dicts()
+
+    assert len(result) == 5
+    assert result[0]["city"] == "Montreal"
+    assert result[1]["city"] == "Calgary"
+    assert result[2]["city"] == "Toronto"
+    assert result[3]["city"] == "Edmonton"
+    assert result[4]["city"] == "Vancouver"
+
+
+def test_benchmark_query4(benchmark, session):
+    result = benchmark(query.run_query4, session, 30, 40)
+    result = result.to_dicts()
+
+    assert len(result) == 3
+    assert result[0]["countries"] == "United States"
+    assert result[1]["countries"] == "Canada"
+    assert result[2]["countries"] == "United Kingdom"
+    assert result[0]["personCounts"] == 30473
+    assert result[1]["personCounts"] == 3064
+    assert result[2]["personCounts"] == 1873
+
+
+def test_benchmark_query5(benchmark, session):
+    result = benchmark(query.run_query5, session, "male", "London", "United Kingdom", "fine dining")
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numPersons"] == 52
+
+
+def test_benchmark_query6(benchmark, session):
+    result = benchmark(query.run_query6, session, "female", "tennis")
+    result = result.to_dicts()
+
+    assert len(result) == 5
+    assert result[0]["numPersons"] == 66
+    assert result[0]["city"] in ("Houston", "Birmingham")
+    assert result[0]["country"] in ("United States", "United Kingdom")
+
+
+def test_benchmark_query7(benchmark, session):
+    result = benchmark(query.run_query7, session, "United States", 23, 30, "photography")
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numPersons"] == 170
+    assert result[0]["state"] == "California"
+    assert result[0]["country"] == "United States"
+
+
+def test_benchmark_query8(benchmark, session):
+    result = benchmark(query.run_query8, session)
+    result = result.to_dicts()
+
+    assert len(result) == 1
+    assert result[0]["numFollowers"] == 1214477

--- a/neo4j/query.py
+++ b/neo4j/query.py
@@ -22,10 +22,11 @@ def run_query1(session: Session) -> None:
         ORDER BY numFollowers DESC LIMIT 3
     """
     print(f"\nQuery 1:\n {query}")
-    with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
-        response = session.run(query)
-        result = pl.from_dicts(response.data())
-        print(f"Top 3 most-followed persons:\n{result}")
+    # with Timer(name="query1", text="Query 1 completed in {:.6f}s"):
+    response = session.run(query)
+    result = pl.from_dicts(response.data())
+    print(f"Top 3 most-followed persons:\n{result}")
+    return result
 
 
 def run_query2(session: Session) -> None:
@@ -37,10 +38,10 @@ def run_query2(session: Session) -> None:
         RETURN person.name AS name, followers AS numFollowers, city.city AS city, city.state AS state, city.country AS country
     """
     print(f"\nQuery 2:\n {query}")
-    with Timer(name="query2", text="Query 2 completed in {:.6f}s"):
-        response = session.run(query)
-        result = pl.from_dicts(response.data())
-        print(f"City in which most-followed person lives:\n{result}")
+    response = session.run(query)
+    result = pl.from_dicts(response.data())
+    print(f"City in which most-followed person lives:\n{result}")
+    return result
 
 
 def run_query3(session: Session, country: str) -> None:
@@ -50,10 +51,10 @@ def run_query3(session: Session, country: str) -> None:
         ORDER BY averageAge LIMIT 5
     """
     print(f"\nQuery 3:\n {query}")
-    with Timer(name="query3", text="Query 3 completed in {:.6f}s"):
-        response = session.run(query, country=country)
-        result = pl.from_dicts(response.data())
-        print(f"Cities with lowest average age in {country}:\n{result}")
+    response = session.run(query, country=country)
+    result = pl.from_dicts(response.data())
+    print(f"Cities with lowest average age in {country}:\n{result}")
+    return result
 
 
 def run_query4(session: Session, age_lower: int, age_upper: int) -> None:
@@ -64,10 +65,10 @@ def run_query4(session: Session, age_lower: int, age_upper: int) -> None:
         ORDER BY personCounts DESC LIMIT 3
     """
     print(f"\nQuery 4:\n {query}")
-    with Timer(name="query4", text="Query 4 completed in {:.6f}s"):
-        response = session.run(query, age_lower=age_lower, age_upper=age_upper)
-        result = pl.from_dicts(response.data())
-        print(f"Persons between ages {age_lower}-{age_upper} in each country:\n{result}")
+    response = session.run(query, age_lower=age_lower, age_upper=age_upper)
+    result = pl.from_dicts(response.data())
+    print(f"Persons between ages {age_lower}-{age_upper} in each country:\n{result}")
+    return result
 
 
 def run_query5(session: Session, gender: str, city: str, country: str, interest: str) -> None:
@@ -81,12 +82,12 @@ def run_query5(session: Session, gender: str, city: str, country: str, interest:
         RETURN count(p) AS numPersons
     """
     print(f"\nQuery 5:\n {query}")
-    with Timer(name="query5", text="Query 5 completed in {:.6f}s"):
-        response = session.run(query, gender=gender, city=city, country=country, interest=interest)
-        result = pl.from_dicts(response.data())
-        print(
-            f"Number of {gender} users in {city}, {country} who have an interest in {interest}:\n{result}"
-        )
+    response = session.run(query, gender=gender, city=city, country=country, interest=interest)
+    result = pl.from_dicts(response.data())
+    print(
+        f"Number of {gender} users in {city}, {country} who have an interest in {interest}:\n{result}"
+    )
+    return result
 
 
 def run_query6(session: Session, gender: str, interest: str) -> None:
@@ -96,14 +97,14 @@ def run_query6(session: Session, gender: str, interest: str) -> None:
         AND tolower(p.gender) = tolower($gender)
         WITH p, i
         MATCH (p)-[:LIVES_IN]->(c:City)
-        RETURN count(p) AS numPersons, c.city, c.country
+        RETURN count(p) AS numPersons, c.city AS city, c.country AS country
         ORDER BY numPersons DESC LIMIT 5
     """
     print(f"\nQuery 6:\n {query}")
-    with Timer(name="query6", text="Query 6 completed in {:.6f}s"):
-        response = session.run(query, gender=gender, interest=interest)
-        result = pl.from_dicts(response.data())
-        print(f"City with the most {gender} users who have an interest in {interest}:\n{result}")
+    response = session.run(query, gender=gender, interest=interest)
+    result = pl.from_dicts(response.data())
+    print(f"Cities with the most {gender} users who have an interest in {interest}:\n{result}")
+    return result
 
 
 def run_query7(
@@ -119,16 +120,16 @@ def run_query7(
         ORDER BY numPersons DESC LIMIT 1
     """
     print(f"\nQuery 7:\n {query}")
-    with Timer(name="query7", text="Query 7 completed in {:.6f}s"):
-        response = session.run(
-            query, country=country, age_lower=age_lower, age_upper=age_upper, interest=interest
-        )
-        result = pl.from_dicts(response.data())
-        print(
-            f"""
-            State in {country} with the most users between ages {age_lower}-{age_upper} who have an interest in {interest}:\n{result}
-            """
-        )
+    response = session.run(
+        query, country=country, age_lower=age_lower, age_upper=age_upper, interest=interest
+    )
+    result = pl.from_dicts(response.data())
+    print(
+        f"""
+        State in {country} with the most users between ages {age_lower}-{age_upper} who have an interest in {interest}:\n{result}
+        """
+    )
+    return result
 
 
 def run_query8(session: Session) -> None:
@@ -138,36 +139,26 @@ def run_query8(session: Session) -> None:
         RETURN count(f) as numFollowers
     """
     print(f"\nQuery 8:\n {query}")
-    with Timer(name="query8", text="Query 8 completed in {:.6f}s"):
-        response = session.run(query)
-        result = pl.from_dicts(response.data())
-        print(f"Number of second degree connections reachable in the graph:\n{result}")
+    response = session.run(query)
+    result = pl.from_dicts(response.data())
+    print(f"Number of second degree connections reachable in the graph:\n{result}")
+    return result
 
 
 def main() -> None:
     with GraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD)) as driver:
         with driver.session(database="neo4j") as session:
-            with Timer(name="queries", text="Query script completed in {:.6f}s"):
-                run_query1(session)
-                run_query2(session)
-                run_query3(session, country="Canada")
-                run_query4(session, age_lower=30, age_upper=40)
-                run_query5(
-                    session,
-                    gender="male",
-                    city="London",
-                    country="United Kingdom",
-                    interest="fine dining",
-                )
-                run_query6(session, gender="female", interest="tennis")
-                run_query7(
-                    session,
-                    country="United States",
-                    age_lower=23,
-                    age_upper=30,
-                    interest="photography",
-                )
-                run_query8(session)
+            with Timer(name="queries", text="Neo4j query script completed in {:.6f}s"):
+                # fmt: off
+                _ = run_query1(session)
+                _ = run_query2(session)
+                _ = run_query3(session, country="Canada")
+                _ = run_query4(session, age_lower=30, age_upper=40)
+                _ = run_query5(session, gender="male", city="London", country="United Kingdom", interest="fine dining")
+                _ = run_query6(session, gender="female", interest="tennis")
+                _ = run_query7(session, country="United States", age_lower=23, age_upper=30, interest="photography")
+                _ = run_query8(session)
+                # fmt: on
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ kuzu>=0.0.6
 neo4j~=5.11.0
 python-dotenv>=1.0.0
 codetiming>=1.4.0
+pytest-benchmark>=4.0.0


### PR DESCRIPTION
## Goals

To do a more rigorous study, it makes sense to use a benchmarking library to run the benchmarks with warmup baked in. This PR adds support for running the benchmarks via `pytest-benchmark`. This is also useful when testing the performance of the new `MERGE` keyword in Kùzu 0.7.0.

- [x] Use `pytest-benchmark` to more formally run the benchmark over multiple runs
- [x] Update docs with the latest benchmark numbers

## To do
- [ ] Test the performance of the `MERGE` keyword in Kùzu 
