### PR TITLE
Zstd parquet

### DIFF
--- a/data/create_edges_follows.py
+++ b/data/create_edges_follows.py
@@ -97,7 +97,7 @@ def main() -> None:
         edges_df = edges_df.head(NUM)
         print(f"Limiting edges to {NUM} per the `--num` argument")
     # Write nodes
-    edges_df.write_parquet(Path("output/edges") / "follows.parquet", compression="snappy")
+    edges_df.write_parquet(Path("output/edges") / "follows.parquet")
     print(f"Wrote {len(edges_df)} edges for {len(persons_df)} persons")
 
 

--- a/data/create_edges_interests.py
+++ b/data/create_edges_interests.py
@@ -51,7 +51,7 @@ def main() -> None:
         print(f"Limiting edges to {NUM} per the `--num` argument")
     # Write nodes
     edges_df = edges_df.rename({"id": "from", "interests": "to"})
-    edges_df.write_parquet(Path("output/edges") / "interests.parquet", compression="snappy")
+    edges_df.write_parquet(Path("output/edges") / "interests.parquet")
     print(f"Wrote {len(edges_df)} edges for {len(persons_df)} persons")
 
 

--- a/data/create_edges_location.py
+++ b/data/create_edges_location.py
@@ -51,7 +51,6 @@ def main() -> None:
     # Write nodes
     edges_df = edges_df.rename({"city_id": "to", "id": "from"}).write_parquet(
         Path("output/edges") / "lives_in.parquet",
-        compression="snappy",
     )
     print(f"Generated residence cities for persons. Top 5 common cities are: {', '.join(top_5)}")
 

--- a/data/create_edges_location_city_state.py
+++ b/data/create_edges_location_city_state.py
@@ -26,7 +26,7 @@ def main() -> None:
         .rename({"city_id": "from", "state_id": "to"})
     )
     # Write nodes
-    edges_df.write_parquet(Path("output/edges") / "city_in.parquet", compression="snappy")
+    edges_df.write_parquet(Path("output/edges") / "city_in.parquet")
     print(f"Wrote {len(edges_df)} edges for {len(cities_df)} cities")
 
 

--- a/data/create_edges_location_state_country.py
+++ b/data/create_edges_location_state_country.py
@@ -22,7 +22,7 @@ def main() -> None:
         .rename({"state_id": "from", "country_id": "to"})
     )
     # Write nodes
-    edges_df.write_parquet(Path("output/edges") / "state_in.parquet", compression="snappy")
+    edges_df.write_parquet(Path("output/edges") / "state_in.parquet")
     print(f"Wrote {len(edges_df)} edges for {len(states_df)} states")
 
 

--- a/data/create_nodes_interests.py
+++ b/data/create_nodes_interests.py
@@ -20,7 +20,6 @@ def main(filename: str) -> pl.DataFrame:
     # Write to csv
     interests_df.select(pl.col("id"), pl.all().exclude("id")).write_parquet(
         Path("output/nodes") / "interests.parquet",
-        compression="snappy",
     )
     print(f"Wrote {interests_df.shape[0]} interests nodes to parquet")
     return interests

--- a/data/create_nodes_location.py
+++ b/data/create_nodes_location.py
@@ -59,7 +59,6 @@ def write_city_nodes(cities_of_interest: pl.DataFrame) -> pl.DataFrame:
     # Write to csv
     city_nodes.select(pl.col("id"), pl.all().exclude("id")).write_parquet(
         Path("output/nodes") / "cities.parquet",
-        compression="snappy",
     )
     print(f"Wrote {city_nodes.shape[0]} cities to parquet")
     return city_nodes

--- a/data/create_nodes_person.py
+++ b/data/create_nodes_person.py
@@ -62,7 +62,6 @@ def main() -> None:
     # Write nodes
     persons_df.select(pl.col("id"), pl.all().exclude("id")).write_parquet(
         Path("output/nodes") / "persons.parquet",
-        compression="snappy",
     )
     print(f"Wrote {persons_df.shape[0]} person nodes to parquet")
 

--- a/kuzudb/benchmark_query.py
+++ b/kuzudb/benchmark_query.py
@@ -1,5 +1,5 @@
 """
-Use the `pytest-benchmark` library to more formally benchmark the Neo4j queries with warmup and iterations.
+Use the `pytest-benchmark` library to more formally benchmark the Kùzu queries with warmup and iterations.
 `pip install pytest-benchmark`
 """
 import pytest

--- a/kuzudb/query.py
+++ b/kuzudb/query.py
@@ -1,5 +1,5 @@
 """
-Run a series of queries on the Neo4j database
+Run a series of queries on an existing Kùzu database
 """
 from typing import Any
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ faker~=19.12.0
 polars~=0.19.0
 numpy>=1.25.0
 pyarrow~=13.0.0
-kuzu==0.0.11
+kuzu==0.0.12
 neo4j~=5.13.0
 python-dotenv>=1.0.0
 codetiming>=1.4.0


### PR DESCRIPTION
Recent Kùzu versions have updated the parquet read/write options and now support zstd compression (which is what polars uses by default). So, if we're creating parquet in polars using zstd compression, we can now read in these parquets in Kùzu whose native parquet reader (and underlying arrow implementation) support zstd compression. No need to use snappy compression any more 😀.
